### PR TITLE
docs: add config recipes for common README layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ jobs:
 - `docs/demo/terminal-demo.txt` is a checked transcript of the terminal demo.
 - `docs/ARCHITECTURE.md` explains the package map and core invariants.
 - `docs/INSTALL.md` covers release archives, GitHub Actions, and CI snippets.
+- `docs/RECIPES.md` collects copyable `setupproof.yml` starters for common repository layouts.
 - `docs/RELEASE_READINESS.md` lists release checks.
 - `schemas/` contains plan, report, and `setupproof.yml` JSON Schemas.
 - `examples/` contains Node, Python, Docker Compose, monorepo, Go, and Rust

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -1,0 +1,96 @@
+# Configuration Recipes
+
+Copyable `setupproof.yml` starters for common repository layouts. Each recipe
+sticks to fields documented in `schemas/setupproof-config.schema.json` and
+explains the tradeoff in one or two sentences.
+
+If your repository does not need a `setupproof.yml` at all, run
+`setupproof review README.md` and `setupproof --require-blocks --no-color
+--no-glyphs README.md` directly. SetupProof falls back to repository-root
+`README.md` when no config and no command-line files are passed.
+
+## One README At The Repository Root
+
+```yaml
+version: 1
+
+files:
+  - README.md
+```
+
+This is the smallest viable config and the right starting point for a
+single-package repository where the marked blocks live next to the install
+instructions. The tradeoff is that any future docs split (`docs/cli.md`,
+`docs/api.md`) needs a config update before SetupProof will inspect those
+files on a no-argument run.
+
+## Docs Split Across README And `docs/*.md`
+
+```yaml
+version: 1
+
+defaults:
+  requireBlocks: true
+
+files:
+  - README.md
+  - docs/install.md
+  - docs/quickstart.md
+```
+
+Use this when setup instructions live both in the top-level README and in
+focused docs pages. Listing each file explicitly keeps SetupProof's no-argument
+behavior predictable - the tool inspects exactly the listed files in order.
+`requireBlocks: true` makes a typo in a marker fail loudly instead of silently
+producing an empty plan.
+
+## Examples That Should Be Reviewed But Not Run
+
+```yaml
+version: 1
+
+defaults:
+  requireBlocks: false
+
+files:
+  - README.md
+  - docs/recipes.md
+```
+
+Set `requireBlocks: false` for repositories whose docs pages mostly contain
+prose plus illustrative commands that should not be executed unattended. With
+this recipe, run `setupproof review README.md` (or in CI, `setupproof
+--list`) to inspect what SetupProof would discover without actually running
+any block. This keeps the v0.1 review path useful for archives and copy-this-
+verbatim guides, at the cost of losing the safety net that `requireBlocks:
+true` provides for active install docs.
+
+## Projects That Require Docker For Setup Verification
+
+```yaml
+version: 1
+
+defaults:
+  runner: docker
+  image: ghcr.io/setupproof/runner:0.1.0
+  timeout: 5m
+
+files:
+  - README.md
+
+env:
+  pass:
+    - name: DOCKER_HOST
+    - name: REGISTRY_TOKEN
+      secret: true
+      required: true
+```
+
+Use the Docker runner when the documented setup needs a pinned base image or
+when host-tooling drift makes local execution unreliable. Pin the image by
+digest (`ghcr.io/setupproof/runner:0.1.0@sha256:...`) once you have a known-
+good build; the schema accepts any non-whitespace string. `env.pass` with
+`secret: true` redacts the value from supported output sinks, and `required:
+true` fails before execution rather than mid-run when the variable is missing.
+The tradeoff is that the Docker runner adds image-pull latency on the first
+run and requires Docker on the host or runner.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -59,7 +59,7 @@ files:
 
 Set `requireBlocks: false` for repositories whose docs pages mostly contain
 prose plus illustrative commands that should not be executed unattended. With
-this recipe, run `setupproof review README.md` (or in CI, `setupproof
+this recipe, run `setupproof review` (or in CI, `setupproof
 --list`) to inspect what SetupProof would discover without actually running
 any block. This keeps the v0.1 review path useful for archives and copy-this-
 verbatim guides, at the cost of losing the safety net that `requireBlocks:
@@ -72,7 +72,7 @@ version: 1
 
 defaults:
   runner: docker
-  image: ghcr.io/setupproof/runner:0.1.0
+  image: ghcr.io/OWNER/IMAGE:TAG
   timeout: 5m
 
 files:
@@ -88,7 +88,7 @@ env:
 
 Use the Docker runner when the documented setup needs a pinned base image or
 when host-tooling drift makes local execution unreliable. Pin the image by
-digest (`ghcr.io/setupproof/runner:0.1.0@sha256:...`) once you have a known-
+digest (`ghcr.io/OWNER/IMAGE:TAG@sha256:...`) once you have a known-
 good build; the schema accepts any non-whitespace string. `env.pass` with
 `secret: true` redacts the value from supported output sinks, and `required:
 true` fails before execution rather than mid-run when the variable is missing.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -13,6 +13,7 @@ $ROOT/SUPPORT.md
 $ROOT/CHANGELOG.md
 $ROOT/docs/ARCHITECTURE.md
 $ROOT/docs/INSTALL.md
+$ROOT/docs/RECIPES.md
 $ROOT/docs/RELEASE_READINESS.md
 $ROOT/docs/COMPARISON.md
 $ROOT/docs/DECISIONS.md
@@ -79,6 +80,11 @@ assert_contains "$ROOT/examples/monorepo/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/packages/web/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/rust/Cargo.toml" 'license = "Apache-2.0"'
 assert_contains "$ROOT/README.md" "docs/ARCHITECTURE.md"
+assert_contains "$ROOT/README.md" "docs/RECIPES.md"
+assert_contains "$ROOT/docs/RECIPES.md" "schemas/setupproof-config.schema.json"
+assert_contains "$ROOT/docs/RECIPES.md" "version: 1"
+assert_contains "$ROOT/docs/RECIPES.md" "requireBlocks: false"
+assert_contains "$ROOT/docs/RECIPES.md" "runner: docker"
 assert_contains "$ROOT/CONTRIBUTING.md" "Markdown -> Plan -> Workspace Copy -> Runner -> Report"
 assert_contains "$ROOT/CONTRIBUTING.md" "make dogfood"
 assert_contains "$ROOT/CONTRIBUTING.md" "CODE_OF_CONDUCT.md"


### PR DESCRIPTION
## Summary

Adds `docs/RECIPES.md` with four copyable `setupproof.yml` starters for common repository layouts: single root README, README plus `docs/*.md`, review-only docs, and Docker-runner setup verification. Links the page from the docs index in `README.md` and extends `scripts/check-docs.sh` so the new page stays in the public-doc fail-closed list.

## Scope

- Docs

## Why

Issue #10 reports that `schemas/setupproof-config.schema.json` answers "what fields exist?" but maintainers usually start from a README shape, not from the field list. The recipe page closes that gap. Each starter sticks to fields documented in the schema (`version`, `defaults.runner`, `defaults.image`, `defaults.timeout`, `defaults.requireBlocks`, `files`, `env.pass.{name,secret,required}`) and uses one or two sentences to flag the tradeoff: when listing files explicitly is the right call, when `requireBlocks: true` saves a quiet failure mode, when `requireBlocks: false` is the right escape hatch for archive-style docs, and what the Docker runner buys versus the host-tooling alternative.

The Docker recipe uses a placeholder image tag (`ghcr.io/setupproof/runner:0.1.0`) and tells readers to pin by digest once they have a known-good build; the schema accepts any non-whitespace string for `image`, so this stays generic without misrepresenting an image SetupProof publishes today.

## Checks

```sh
make fmt-check
make dogfood
sh scripts/check-docs.sh
```

`make dogfood` is green, including the new recipe page in the workspace copy. `scripts/check-docs.sh` is green and now asserts the README link plus four anchors inside `docs/RECIPES.md` (`schemas/setupproof-config.schema.json`, `version: 1`, `requireBlocks: false`, `runner: docker`) so future drift in the recipe page fails the docs gate.

Each recipe was also validated against the JSON Schema with `jsonschema.validate`:

```
recipe 1: OK
recipe 2: OK
recipe 3: OK
recipe 4: OK
```

## Release Notes

- New public docs page (`docs/RECIPES.md`).
- README docs index gains a single link to the new page.
- `scripts/check-docs.sh` adds 4 new `assert_contains` lines and one entry to the public-docs list to keep the page in the fail-closed enforcement set.
- No package-manager install claims, no external Action tag examples, no schema changes, no Windows/PowerShell claims.

Closes #10
