### PR TITLE
Improve contributor and release maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - enhancement
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - enhancement
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,7 @@ make check
 make staticcheck
 make vuln
 make actionlint
+make release-check
 ```
 
 ## Release Notes

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -1,0 +1,51 @@
+name: Release Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/release-checks.yml"
+      - ".github/pull_request_template.md"
+      - "action.yml"
+      - "cmd/**"
+      - "CONTRIBUTING.md"
+      - "docs/**"
+      - "examples/**"
+      - "go.mod"
+      - "go.sum"
+      - "internal/**"
+      - "scripts/**"
+      - "schemas/**"
+      - "Makefile"
+      - "README.md"
+      - "SUPPORT.md"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  full-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.8"
+          cache: true
+      - name: Run repository checks
+        run: make check
+      - name: Run static analysis
+        run: make staticcheck
+      - name: Run vulnerability scan
+        run: make vuln
+      - name: Run workflow lint
+        run: make actionlint
+      - name: Verify release archives
+        run: make release-check VERSION=0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ make check
 make staticcheck
 make vuln
 make actionlint
+make release-check
 ```
 
 `make check` runs the same repository checks documented in
@@ -62,6 +63,27 @@ changes, run the full gate before requesting review.
 Do not include secrets, tokens, private repository data, or vulnerability
 details in public issues or pull requests. Follow `SECURITY.md` for
 security-sensitive reports.
+
+## Claiming Issues
+
+Small documentation, example, and test tasks labeled `good first issue` are good
+places to start. They should already describe the expected behavior and the
+checks to run.
+
+Before starting larger behavior, runner, schema, Action, or release-facing
+changes, comment on the issue with the scope you intend to take. If an issue
+already has a linked pull request, treat it as in progress unless a maintainer
+marks it available again.
+
+Keep pull requests narrow. A good change usually closes one issue, touches one
+area, and leaves unrelated cleanup for a follow-up. If the work exposes a
+larger design question, pause and open a design discussion instead of expanding
+the patch.
+
+The scope rules below still apply to contributor tasks. In particular, do not
+add package-manager install commands, platform support claims, telemetry,
+network calls in non-executing commands, or plan/report JSON changes unless the
+issue explicitly calls for that work.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 VERSION ?= 0.1.0
 LDFLAGS := -X github.com/setupproof/setupproof/internal/app.Version=$(VERSION)
+STATICCHECK_VERSION ?= v0.6.1
+GOVULNCHECK_VERSION ?= v1.1.4
+ACTIONLINT_VERSION ?= v1.7.7
 
-.PHONY: build test vet race fmt fmt-check dogfood foundation action docs examples check staticcheck vuln actionlint release-archives
+.PHONY: build test vet race fmt fmt-check dogfood foundation action docs examples check staticcheck vuln actionlint release-archives release-check
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o ./setupproof ./cmd/setupproof
@@ -39,13 +42,16 @@ examples:
 check: test vet race foundation action docs examples dogfood
 
 staticcheck:
-	go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+	GOTOOLCHAIN=auto go run honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION) ./...
 
 vuln:
-	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	GOTOOLCHAIN=auto go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 actionlint:
-	go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/setupproof.yml
+	GOTOOLCHAIN=auto go run github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION) .github/workflows/setupproof.yml .github/workflows/release-checks.yml
 
 release-archives:
 	scripts/package-release.sh v$(VERSION)
+
+release-check: release-archives
+	scripts/check-release-archives.sh v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ jobs:
 - `docs/ARCHITECTURE.md` explains the package map and core invariants.
 - `docs/INSTALL.md` covers release archives, GitHub Actions, and CI snippets.
 - `docs/RELEASE_READINESS.md` lists release checks.
+- `docs/TROUBLESHOOTING.md` maps common failure output to the next command to
+  run.
 - `schemas/` contains plan, report, and `setupproof.yml` JSON Schemas.
 - `examples/` contains Node, Python, Docker Compose, monorepo, Go, and Rust
   fixtures.
@@ -184,7 +186,7 @@ For release-oriented changes, also run:
 make staticcheck
 make vuln
 make actionlint
-make release-archives
+make release-check
 ```
 
 ## License

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,6 +13,10 @@ For help with a SetupProof run, include:
 - `setupproof review README.md` output for the block;
 - the Markdown or JSON report when it is safe to share.
 
+`docs/TROUBLESHOOTING.md` maps common failures to the next command to run,
+including no marked blocks, timeouts, interactive commands, Docker startup
+problems, and missing required environment variables.
+
 Do not include secrets, private hostnames, or unredacted command logs in public
 support requests. SetupProof redacts configured secrets, but transformed or
 partial secrets may still appear in project command output.

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -13,13 +13,24 @@ Before tagging a release, verify:
 - `sh scripts/check-docs.sh`
 - `sh scripts/check-examples.sh`
 - `make release-archives VERSION=<major.minor.patch>`
+- `make release-check VERSION=<major.minor.patch>`
 
 Release archive gates:
 
 - Linux and macOS archives exist for `amd64` and `arm64`.
 - The checksum manifest includes every archive.
+- `scripts/check-release-archives.sh` verifies archive contents and checksums.
 - Each extracted binary prints the expected version with `setupproof --version`.
 - The GitHub release body includes the Go install command and the Action pin.
+
+Release automation gates:
+
+- `.github/workflows/release-checks.yml` runs the full repository gate, static
+  analysis, vulnerability scan, workflow lint, and archive verification.
+- The release checks workflow uses a patched Go toolchain for release and
+  security gates rather than the oldest module language version.
+- Keep the required SetupProof workflow small and fast; add slower
+  release-oriented checks to the release checks workflow.
 
 Action wrapper gates:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,119 @@
+# Troubleshooting
+
+Use non-executing commands first when a setup-doc check is confusing:
+
+```sh
+setupproof review README.md
+setupproof doctor README.md
+setupproof --dry-run --json --require-blocks README.md
+```
+
+Then run the marked blocks once the plan matches the setup path you expect:
+
+```sh
+setupproof --require-blocks --no-color --no-glyphs README.md
+```
+
+## No Marked Blocks Found
+
+`No marked blocks found.` means SetupProof did not find an explicitly marked
+shell fence in the selected files.
+
+Check that the command is reading the file that contains the setup commands. If
+you use `setupproof.yml`, run without positional files to use the configured
+targets, or pass every Markdown file explicitly.
+
+Use `--require-blocks` in CI so a renamed file, removed marker, or typo in a
+marker fails loudly instead of producing an empty run.
+
+## Command Failed
+
+A line such as this is an ordinary setup command failure:
+
+```text
+[failed] README.md#quickstart file=README.md:18 runner=local timeout=120s result=failed exit=1 reason=exit-code
+```
+
+Run `setupproof review README.md` to confirm the exact source command, shell,
+runner, and timeout. Then run the command manually from a clean checkout if the
+failure needs project-specific debugging.
+
+## Timeout
+
+Timeout failures report `result=timeout` and keep the source file and block ID
+in the output. Increase the timeout only for setup steps that are expected to be
+slow:
+
+````md
+<!-- setupproof id=quickstart timeout=5m -->
+```sh
+go test ./...
+```
+````
+
+Prefer fixing unexpectedly slow setup commands before raising the timeout in CI.
+
+## Interactive Command
+
+SetupProof closes stdin and does not allocate a TTY. Commands such as `read`,
+interactive package prompts, or login flows fail before they can hang the run.
+
+Move interactive steps outside the marked block, or replace them with
+non-interactive flags that are safe for CI.
+
+## Missing Shell Or Unsupported Platform
+
+Marked shell fences need a supported shell. In v0.1, use `sh`, `bash`, or
+`shell` fences.
+
+Native Windows execution and PowerShell fences are unsupported in v0.1. On
+Windows, run SetupProof through WSL2.
+
+## Docker Runner Problems
+
+Run `setupproof doctor README.md` when a Docker-backed block fails before the
+project command starts.
+
+Common causes:
+
+- Docker is not installed or the daemon is not reachable.
+- The configured image cannot be pulled.
+- The first image pull is slow enough to hit a short timeout.
+- The image tag is mutable or the digest is missing.
+
+Prefer digest-pinned images for CI. Docker improves isolation from host tooling
+drift, but it is not a security sandbox for hostile commands.
+
+## Missing Environment Variables
+
+Required variables configured in `setupproof.yml` fail before execution when
+they are missing:
+
+```yaml
+version: 1
+
+env:
+  pass:
+    - name: REGISTRY_TOKEN
+      secret: true
+      required: true
+```
+
+Run `setupproof doctor README.md` to check required variables without executing
+marked blocks. Do not paste secret values into public issues, pull requests, or
+logs.
+
+## What To Include In A Support Issue
+
+Include:
+
+- `setupproof --version`
+- operating system and architecture
+- runner (`local`, `action-local`, or `docker`)
+- the command you ran
+- the relevant file path and block ID
+- `setupproof review README.md` output for the block
+- a redacted Markdown or JSON report when it is safe to share
+
+Do not include secrets, private hostnames, or full unredacted command logs in
+public issues.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -14,6 +14,7 @@ $ROOT/CHANGELOG.md
 $ROOT/docs/ARCHITECTURE.md
 $ROOT/docs/INSTALL.md
 $ROOT/docs/RELEASE_READINESS.md
+$ROOT/docs/TROUBLESHOOTING.md
 $ROOT/docs/COMPARISON.md
 $ROOT/docs/DECISIONS.md
 $ROOT/.github/labels.yml
@@ -79,11 +80,20 @@ assert_contains "$ROOT/examples/monorepo/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/packages/web/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/rust/Cargo.toml" 'license = "Apache-2.0"'
 assert_contains "$ROOT/README.md" "docs/ARCHITECTURE.md"
+assert_contains "$ROOT/README.md" "docs/TROUBLESHOOTING.md"
 assert_contains "$ROOT/CONTRIBUTING.md" "Markdown -> Plan -> Workspace Copy -> Runner -> Report"
+assert_contains "$ROOT/CONTRIBUTING.md" "Claiming Issues"
+assert_contains "$ROOT/CONTRIBUTING.md" "linked pull request"
 assert_contains "$ROOT/CONTRIBUTING.md" "make dogfood"
 assert_contains "$ROOT/CONTRIBUTING.md" "CODE_OF_CONDUCT.md"
+assert_contains "$ROOT/SUPPORT.md" "docs/TROUBLESHOOTING.md"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "setupproof doctor README.md"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "No Marked Blocks Found"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "Docker Runner Problems"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "Missing Environment Variables"
 assert_contains "$ROOT/.github/pull_request_template.md" "make check"
 assert_contains "$ROOT/.github/pull_request_template.md" "make fmt-check"
+assert_contains "$ROOT/.github/pull_request_template.md" "make release-check"
 assert_contains "$ROOT/.github/ISSUE_TEMPLATE/bug_report.md" 'labels: "bug"'
 assert_contains "$ROOT/.github/ISSUE_TEMPLATE/setup-doc-failure.md" 'labels: "support"'
 assert_contains "$ROOT/.github/ISSUE_TEMPLATE/contributor_task.md" "make fmt-check"
@@ -92,6 +102,9 @@ assert_contains "$ROOT/docs/ARCHITECTURE.md" "Unmarked Markdown blocks never exe
 assert_contains "$ROOT/docs/ARCHITECTURE.md" "Report JSON is machine-facing output"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "Moving major Action tags"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "make release-archives"
+assert_contains "$ROOT/docs/RELEASE_READINESS.md" "make release-check"
+assert_contains "$ROOT/docs/RELEASE_READINESS.md" "scripts/check-release-archives.sh"
+assert_contains "$ROOT/docs/RELEASE_READINESS.md" "patched Go toolchain"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "CODE_OF_CONDUCT.md"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "The SetupProof workflow is green on"
 assert_contains "$ROOT/.github/repository-metadata.yml" "github-actions"

--- a/scripts/check-release-archives.sh
+++ b/scripts/check-release-archives.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+  printf 'usage: scripts/check-release-archives.sh v0.1.0\n' >&2
+  exit 2
+fi
+
+case "$VERSION" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  [0-9]*.[0-9]*.[0-9]*) VERSION="v$VERSION" ;;
+  *)
+    printf 'check-release-archives: version must look like v0.1.0\n' >&2
+    exit 2
+    ;;
+esac
+
+PLAIN_VERSION="${VERSION#v}"
+DIST="$ROOT/dist/$VERSION"
+MANIFEST="$DIST/setupproof_${PLAIN_VERSION}_checksums.txt"
+
+fail() {
+  printf 'check-release-archives: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -d "$DIST" ] || fail "missing release directory: $DIST"
+[ -f "$MANIFEST" ] || fail "missing checksum manifest: $MANIFEST"
+
+archive_count=$(find "$DIST" -maxdepth 1 -type f -name '*.tar.gz' | wc -l | tr -d ' ')
+[ "$archive_count" = "4" ] || fail "expected 4 archives, found $archive_count"
+
+manifest_count=$(wc -l < "$MANIFEST" | tr -d ' ')
+[ "$manifest_count" = "$archive_count" ] || fail "manifest lists $manifest_count entries for $archive_count archives"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$DIST" && sha256sum -c "$(basename "$MANIFEST")")
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$DIST" && shasum -a 256 -c "$(basename "$MANIFEST")")
+else
+  fail "sha256sum or shasum is required"
+fi
+
+for archive in "$DIST"/*.tar.gz; do
+  name=$(basename "$archive")
+  count=$(awk -v name="$name" '$2 == name { count++ } END { print count + 0 }' "$MANIFEST")
+  [ "$count" = "1" ] || fail "manifest must list $name exactly once"
+
+  contents=$(tar -tzf "$archive")
+  printf '%s\n' "$contents" | grep -Fx './setupproof' >/dev/null || fail "$name missing setupproof"
+  printf '%s\n' "$contents" | grep -Fx './LICENSE' >/dev/null || fail "$name missing LICENSE"
+  printf '%s\n' "$contents" | grep -Fx './NOTICE' >/dev/null || fail "$name missing NOTICE"
+done
+
+host_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$host_os" in
+  darwin|linux) ;;
+  *) fail "unsupported host OS for binary smoke test: $host_os" ;;
+esac
+
+host_arch=$(uname -m)
+case "$host_arch" in
+  x86_64|amd64) host_arch=amd64 ;;
+  arm64|aarch64) host_arch=arm64 ;;
+  *) fail "unsupported host architecture for binary smoke test: $host_arch" ;;
+esac
+
+host_archive="$DIST/setupproof_${PLAIN_VERSION}_${host_os}_${host_arch}.tar.gz"
+[ -f "$host_archive" ] || fail "missing host archive: $(basename "$host_archive")"
+
+tmp="${TMPDIR:-/tmp}/setupproof-release-check-$$"
+rm -rf "$tmp"
+mkdir -p "$tmp"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+tar -xzf "$host_archive" -C "$tmp"
+[ -x "$tmp/setupproof" ] || fail "host archive setupproof is not executable"
+
+version_output=$("$tmp/setupproof" --version)
+[ "$version_output" = "setupproof $PLAIN_VERSION" ] || fail "unexpected version output: $version_output"
+
+printf 'release archive checks passed\n'


### PR DESCRIPTION
## Summary

- Add issue-claiming guidance for contributors.
- Add troubleshooting docs for common SetupProof failure modes.
- Add release archive verification and a release checks workflow.
- Add Dependabot coverage for Go modules and GitHub Actions.

Closes #15
Closes #16
Closes #17

## Checks

```sh
git diff --check
sh -n scripts/check-release-archives.sh scripts/check-docs.sh scripts/package-release.sh
make docs
make actionlint
make release-check VERSION=0.1.0
make check
make fmt-check
make staticcheck
make vuln
```
