### PR TITLE
Run release checks on every PR

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -2,23 +2,6 @@ name: Release Checks
 
 on:
   pull_request:
-    paths:
-      - ".github/dependabot.yml"
-      - ".github/workflows/release-checks.yml"
-      - ".github/pull_request_template.md"
-      - "action.yml"
-      - "cmd/**"
-      - "CONTRIBUTING.md"
-      - "docs/**"
-      - "examples/**"
-      - "go.mod"
-      - "go.sum"
-      - "internal/**"
-      - "scripts/**"
-      - "schemas/**"
-      - "Makefile"
-      - "README.md"
-      - "SUPPORT.md"
   push:
     branches:
       - main


### PR DESCRIPTION
Summary
- Remove the path filter from Release Checks so `full-gate` reports for every pull request.
- Keep the push and manual triggers unchanged.

Checks
- make check
- make actionlint