### PR TITLE
examples: add a failing fixture demonstrating drift detection

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,11 +14,12 @@ Examples included:
 | `monorepo` | Configured multi-file example using `setupproof.yml`. | list, review, plan, execution when `npm` is available |
 | `go` | No-config path that uses root `README.md`. | list, review, plan, execution |
 | `rust` | Cargo test example with no third-party crates. | list, review, plan |
+| `failing-go` | Intentionally drifted README path (marked block points to a moved package). Demonstrates SetupProof's failure output end-to-end. | list, review, plan, execution (asserts `result=failed`) |
 
 Manual runs need the matching project toolchain. The `python-pip` example needs
 `python3`, and the `docker-compose` example needs Docker Compose.
 
 Smoke coverage lives in `scripts/check-examples.sh`. It validates all example
 Markdown with `--list`, `review`, and `--dry-run --json`, then executes the Go
-no-config example and the configured monorepo example from temporary Git
-repositories.
+no-config example, the configured monorepo example, and the failing-go example
+(asserted to fail) from temporary Git repositories.

--- a/examples/failing-go/README.md
+++ b/examples/failing-go/README.md
@@ -1,0 +1,43 @@
+# Failing Go Example
+
+This fixture shows what SetupProof reports when a marked README block has
+drifted from the project layout. It is intentionally checked in as a
+failing example so maintainers can verify SetupProof's failure output
+end-to-end, and so the docs have a concrete reference for "what does a
+real failure look like".
+
+The marked block targets `./internal/greeter`, but the package actually
+lives under `./pkg/greeter` (a common drift pattern: a contributor moves
+a package and forgets to update the README). Running the block from a
+clean checkout fails with an exit-1 from `go test`.
+
+<!-- setupproof id=failing-go-test -->
+```sh
+go test ./internal/greeter
+```
+
+## Expected output
+
+When SetupProof runs this README from a clean checkout, the marked block
+fails because the imported path does not exist. The exact line offset
+varies as this README evolves, but the result line is stable:
+
+```text
+[failed] README.md#failing-go-test file=README.md:<line> runner=local timeout=120s result=failed exit=1
+```
+
+The corresponding `go test` failure that drives `exit=1` is the standard
+"no Go files" / "package … is not in std" error.
+
+## When a maintainer would use this
+
+- Verifying SetupProof's failure path after a release-candidate change
+  to the runner or reporter.
+- Demonstrating to new contributors what a drifted README looks like
+  through the SetupProof lens, without having to break a real example.
+- Smoke coverage in `scripts/check-examples.sh` (`failing-go-test`
+  appears in `--list` / `review` / `--dry-run --json` output, and the
+  example's actual execution is asserted to produce `result=failed`).
+
+`./pkg/greeter` is the real package and has a passing unit test. The
+drift is purely in the README path.

--- a/examples/failing-go/go.mod
+++ b/examples/failing-go/go.mod
@@ -1,0 +1,3 @@
+module example.com/setupproof-failing-go
+
+go 1.22

--- a/examples/failing-go/pkg/greeter/greeter.go
+++ b/examples/failing-go/pkg/greeter/greeter.go
@@ -1,0 +1,5 @@
+package greeter
+
+func Greet(name string) string {
+	return "hello, " + name
+}

--- a/examples/failing-go/pkg/greeter/greeter_test.go
+++ b/examples/failing-go/pkg/greeter/greeter_test.go
@@ -1,0 +1,11 @@
+package greeter
+
+import "testing"
+
+func TestGreet(t *testing.T) {
+	got := Greet("world")
+	want := "hello, world"
+	if got != want {
+		t.Fatalf("Greet(world) = %q, want %q", got, want)
+	}
+}

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -41,6 +41,7 @@ examples/monorepo/docs/web.md
 examples/monorepo/docs/api.md
 examples/go/README.md
 examples/rust/README.md
+examples/failing-go/README.md
 '
 
 BIN="$TMP_ROOT/setupproof"
@@ -56,7 +57,7 @@ BIN="$TMP_ROOT/setupproof"
   "$BIN" --dry-run --json --require-blocks $EXAMPLE_MARKDOWN > "$TMP_ROOT/plan.json"
 )
 
-for id in node-npm-test python-pip-test docker-compose-smoke web-package api-service go-test rust-cargo-test; do
+for id in node-npm-test python-pip-test docker-compose-smoke web-package api-service go-test rust-cargo-test failing-go-test; do
   assert_contains "$TMP_ROOT/list.txt" "id=$id"
   assert_contains "$TMP_ROOT/review.txt" "#$id"
   assert_contains "$TMP_ROOT/plan.json" "\"id\":\"$id\""
@@ -110,6 +111,19 @@ init_git_repo "$GO_EXAMPLE"
 )
 assert_contains "$TMP_ROOT/go-execution.txt" 'result=passed'
 assert_contains "$TMP_ROOT/go-execution.txt" 'README.md#go-test'
+
+FAILING_GO_EXAMPLE="$TMP_ROOT/failing-go-example"
+mkdir -p "$FAILING_GO_EXAMPLE"
+cp -R "$ROOT/examples/failing-go/." "$FAILING_GO_EXAMPLE"
+init_git_repo "$FAILING_GO_EXAMPLE"
+# This example is expected to fail; run with `|| true` so `set -e` doesn't trip
+# on the deliberate non-zero exit, then assert the failure was the one we expect.
+(
+  cd "$FAILING_GO_EXAMPLE"
+  "$BIN" --require-blocks --no-color --no-glyphs > "$TMP_ROOT/failing-go-execution.txt" || true
+)
+assert_contains "$TMP_ROOT/failing-go-execution.txt" 'result=failed'
+assert_contains "$TMP_ROOT/failing-go-execution.txt" 'README.md#failing-go-test'
 
 if command -v python3 >/dev/null 2>&1 && python3 -m venv "$TMP_ROOT/python-venv-probe" >/dev/null 2>&1; then
   PYTHON_EXAMPLE="$TMP_ROOT/python-example"


### PR DESCRIPTION
## Summary

Closes #8.

Adds `examples/failing-go/`, a small fixture whose marked README block points at
`./internal/greeter` while the real package lives under `./pkg/greeter`. The
drift is the exact pattern the issue called out (a moved package path), and
SetupProof reports it cleanly:

```
[failed] README.md#failing-go-test file=README.md:15 runner=local timeout=120s result=failed exit=1 reason=exit-code
```

Every existing example is a passing case. Without a checked-in failing case,
the failure path is something maintainers reproduce ad-hoc when verifying
SetupProof's output, and the docs have nowhere concrete to point at when
explaining "this is what a drifted README looks like through SetupProof's lens."
This fixture makes that path a durable reference.

What's in the example:

- `examples/failing-go/README.md` — marked `failing-go-test` block running
  `go test ./internal/greeter`. Above the block: short explanation of the
  drift pattern. Below: the expected `result=failed exit=1` line and a
  "When a maintainer would use this" section (per acceptance criterion 3).
- `examples/failing-go/pkg/greeter/` — the real package with a passing unit
  test, so the project itself isn't broken; only the README reference is.
- `examples/failing-go/go.mod` — module declaration, no third-party deps,
  matches the existing `examples/go/` shape.

Smoke coverage in `scripts/check-examples.sh` adds three things:

1. `examples/failing-go/README.md` joins `EXAMPLE_MARKDOWN`, so it participates
   in the existing `--list` / `review` / `--dry-run --json` assertions.
2. `failing-go-test` joins the ID assertion loop.
3. A new end-to-end execution block runs SetupProof against a temp git copy
   of the example, captures stdout (with `|| true` so `set -e` doesn't trip
   on the deliberate non-zero exit), and asserts `result=failed` plus the
   qualified `README.md#failing-go-test` ID.

`examples/README.md` picks up a new row and the smoke-coverage paragraph
mentions the failing example explicitly.

Acceptance criteria mapping:

- [x] Failing fixture under `examples/` (`examples/failing-go/`).
- [x] Example shows the marked README block and the resulting failure output
      (in `examples/failing-go/README.md`).
- [x] Docs explain when a maintainer would use this example
      ("When a maintainer would use this" section).
- [x] Fixture is covered by an existing examples check
      (new execution block in `scripts/check-examples.sh`).

## Scope

- Docs
- Examples
- Tests

## Checks

```sh
bash scripts/check-examples.sh
```

Output ends with `example checks passed`. The new failing example's `result=failed`
plus `README.md#failing-go-test` assertions all hit.

`go test ./examples/failing-go/...` also passes locally — the real package's
unit test is green, only the README path is intentionally drifted.

## Release Notes

- New fixture under `examples/failing-go/` is a teaching/regression aid only.
  No public-API change, no schema change, no Action change. Existing examples
  unchanged.
