### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run workflow lint
         run: make actionlint
       - name: Verify release archives
-        run: make release-check VERSION=0.1.0
+        run: make release-check VERSION=0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.1 - 2026-06-26
+
+- Added a failing Go fixture that demonstrates README drift detection.
+- Improved GitHub Action step summaries with failure location, next command,
+  source, and output-tail context.
+- Added npm packed-tarball release tooling and smoke checks.
+- Documented Docker runner tradeoffs and trust boundaries.
+- Updated release checks for the current Action dependency set.
+
 ## 0.1.0 - 2026-05-01
 
 - Initial public release.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-VERSION ?= 0.1.0
+VERSION ?= 0.1.1
 LDFLAGS := -X github.com/setupproof/setupproof/internal/app.Version=$(VERSION)
 STATICCHECK_VERSION ?= v0.6.1
 GOVULNCHECK_VERSION ?= v1.1.4
 ACTIONLINT_VERSION ?= v1.7.7
 
-.PHONY: build test vet race fmt fmt-check dogfood foundation action docs examples check staticcheck vuln actionlint release-archives release-check
+.PHONY: build test vet race fmt fmt-check dogfood foundation action docs examples check staticcheck vuln actionlint release-archives npm-package npm-check release-check
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o ./setupproof ./cmd/setupproof
@@ -53,5 +53,12 @@ actionlint:
 release-archives:
 	scripts/package-release.sh v$(VERSION)
 
-release-check: release-archives
+npm-package: release-archives
+	scripts/package-npm.sh v$(VERSION)
+
+npm-check: npm-package
+	scripts/check-npm-package.sh v$(VERSION)
+
+release-check: release-archives npm-package
 	scripts/check-release-archives.sh v$(VERSION)
+	scripts/check-npm-package.sh v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ are exactly the failures SetupProof makes visible.
 Prerequisites: Go 1.22 or newer, Git, and a POSIX shell.
 
 ```sh
-go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.0
+go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1
 setupproof --version
 ```
 
@@ -134,15 +134,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: setupproof/setupproof@v0.1.0
+      - uses: setupproof/setupproof@v0.1.1
         with:
-          cli-version: v0.1.0
+          cli-version: v0.1.1
           mode: review
           require-blocks: "true"
           files: README.md
-      - uses: setupproof/setupproof@v0.1.0
+      - uses: setupproof/setupproof@v0.1.1
         with:
-          cli-version: v0.1.0
+          cli-version: v0.1.1
           require-blocks: "true"
           files: README.md
 ```
@@ -164,6 +164,7 @@ jobs:
 - `docs/demo/terminal-demo.sh` regenerates a short terminal demo from source.
 - `docs/demo/terminal-demo.txt` is a checked transcript of the terminal demo.
 - `docs/ARCHITECTURE.md` explains the package map and core invariants.
+- `docs/DOCKER_RUNNER.md` documents Docker runner tradeoffs and trust boundaries.
 - `docs/INSTALL.md` covers release archives, GitHub Actions, and CI snippets.
 - `docs/RECIPES.md` collects copyable `setupproof.yml` starters for common repository layouts.
 - `docs/RELEASE_READINESS.md` lists release checks.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -6,9 +6,10 @@ in `docs/adr/`.
 ## Runtime
 
 SetupProof uses a Go CLI. The GitHub Action is a composite Action that invokes
-the CLI. v0.1.0 is distributed through `go install`, GitHub release archives,
-and a pinned composite Action. npm and operating-system package managers remain
-deferred until their package checks exist.
+the CLI. v0.1.1 is distributed through `go install`, GitHub release archives,
+and a pinned composite Action. The release tooling also stages and smoke-tests
+an npm tarball; npm registry publication and operating-system package managers
+remain deferred until those packages exist.
 
 ## Markers
 

--- a/docs/DOCKER_RUNNER.md
+++ b/docs/DOCKER_RUNNER.md
@@ -1,0 +1,108 @@
+# Docker Runner
+
+Use the Docker runner when the documented setup path needs a pinned toolchain
+image or when host-tooling drift makes local execution too noisy.
+
+Docker is an isolation upgrade from running directly on the host. It is not a
+security sandbox for hostile commands. Treat marked blocks from untrusted pull
+requests the same way you treat the project test suite: run them without
+repository secrets, prefer ephemeral hosted runners, and review the plan before
+execution.
+
+## How It Runs
+
+For each target file, SetupProof copies the Git workspace to a temporary host
+directory, starts a container, and bind-mounts that copied workspace at
+`/workspace`.
+
+The container starts with:
+
+- read-only root filesystem;
+- `tmpfs` at `/tmp`;
+- dropped Linux capabilities;
+- `no-new-privileges`;
+- the host UID/GID when available;
+- SetupProof-managed home, temp, and cache directories under
+  `/workspace/.setupproof`.
+
+Blocks in the same Markdown file share shell state and one container by default.
+Set `isolated: true` for a block or default when each marked block should get a
+fresh workspace and container.
+
+One execution cannot mix Docker and non-Docker runners. Shared blocks in one
+file must also use one Docker image; use `isolated: true` when different blocks
+need different images.
+
+## Image Choice
+
+Pin CI images by digest once the setup path is known:
+
+```yaml
+version: 1
+
+defaults:
+  runner: docker
+  image: ghcr.io/OWNER/IMAGE:TAG@sha256:...
+  timeout: 5m
+
+files:
+  - README.md
+```
+
+Tags are fine for local exploration, but mutable tags can make README checks
+change without a repository diff. The image must contain the shell and tools
+used by the marked block.
+
+Docker image pulls happen before the marked command starts, so account for pull
+latency in the CI job timeout. The per-block timeout covers the command
+execution after the container is running.
+
+## Network
+
+Docker is the only v0.1 runner that can enforce `network: false`:
+
+```yaml
+version: 1
+
+defaults:
+  runner: docker
+  image: ghcr.io/OWNER/IMAGE:TAG@sha256:...
+  network: false
+```
+
+With `network: false`, SetupProof starts the container with `--network none`.
+Without it, Docker's default container networking applies.
+
+## Environment
+
+SetupProof does not copy the host environment wholesale. It sets a small
+baseline environment and passes only variables listed in `setupproof.yml`.
+
+```yaml
+version: 1
+
+env:
+  pass:
+    - name: REGISTRY_TOKEN
+      secret: true
+      required: true
+```
+
+`secret: true` redacts exact values from supported output sinks. Avoid printing
+derived secrets, partial secrets, or private infrastructure names in marked
+commands.
+
+## When Not To Use It
+
+Do not use the Docker runner when:
+
+- the setup path needs privileged Docker, host networking, or the host Docker
+  socket;
+- the commands are interactive;
+- the repository needs multiple long-running services instead of a README
+  quickstart check;
+- the goal is to safely execute hostile code.
+
+Use a project-specific CI job for full environment orchestration. Use
+SetupProof for the narrow promise that the documented first-run commands still
+work.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,15 +1,15 @@
 # Install And CI
 
-SetupProof v0.1.0 ships as a Go module, GitHub release archives, and a
-versioned composite GitHub Action. npm, Homebrew, winget, Chocolatey, and Scoop
-packages are not published yet.
+SetupProof v0.1.1 ships as a Go module, GitHub release archives, and a
+versioned composite GitHub Action. npm registry, Homebrew, winget, Chocolatey,
+and Scoop packages are not published yet.
 
 ## Go Install
 
 Prerequisites: Go 1.22 or newer, Git, and a POSIX shell.
 
 ```sh
-go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.0
+go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1
 setupproof --version
 setupproof review README.md
 setupproof --require-blocks --no-color --no-glyphs README.md
@@ -23,11 +23,11 @@ archive with the matching checksum manifest before running it.
 
 Archive names:
 
-- `setupproof_0.1.0_linux_amd64.tar.gz`
-- `setupproof_0.1.0_linux_arm64.tar.gz`
-- `setupproof_0.1.0_darwin_amd64.tar.gz`
-- `setupproof_0.1.0_darwin_arm64.tar.gz`
-- `setupproof_0.1.0_checksums.txt`
+- `setupproof_0.1.1_linux_amd64.tar.gz`
+- `setupproof_0.1.1_linux_arm64.tar.gz`
+- `setupproof_0.1.1_darwin_amd64.tar.gz`
+- `setupproof_0.1.1_darwin_arm64.tar.gz`
+- `setupproof_0.1.1_checksums.txt`
 
 ## Source Checkout
 
@@ -41,7 +41,7 @@ make build
 ```
 
 Use `make build VERSION=<tag>` when building a release binary from a tagged
-checkout. Use `make release-archives VERSION=0.1.0` to build the release
+checkout. Use `make release-archives VERSION=0.1.1` to build the release
 archive set locally.
 
 For a new project, `setupproof init` writes only `setupproof.yml` by default.
@@ -83,15 +83,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: setupproof/setupproof@v0.1.0
+      - uses: setupproof/setupproof@v0.1.1
         with:
-          cli-version: v0.1.0
+          cli-version: v0.1.1
           mode: review
           require-blocks: "true"
           files: README.md
-      - uses: setupproof/setupproof@v0.1.0
+      - uses: setupproof/setupproof@v0.1.1
         with:
-          cli-version: v0.1.0
+          cli-version: v0.1.1
           require-blocks: "true"
           files: README.md
 ```
@@ -171,7 +171,8 @@ v0.1 platform support:
 - macOS is best effort. Shell behavior can differ from Linux, so run
   `setupproof doctor README.md` before relying on macOS-only CI.
 - Docker runner support requires Docker and is an isolation upgrade, not a
-  security sandbox for hostile commands.
+  security sandbox for hostile commands. See `docs/DOCKER_RUNNER.md` for image,
+  network, and environment tradeoffs.
 - Git submodules and linked worktrees are treated as their own repository
   boundary when their `.git` metadata is a file. `setupproof doctor` reports
   that layout so path resolution surprises are visible before execution.
@@ -186,14 +187,14 @@ blocks.
 
 ## Distribution Status
 
-Published for v0.1.0:
+Published for v0.1.1:
 
 - Go install from the public module path.
 - Linux and macOS release archives with checksums.
-- Versioned GitHub Action usage with `cli-version: v0.1.0`.
+- Versioned GitHub Action usage with `cli-version: v0.1.1`.
 
 Deferred until implemented and verified:
 
-- npm package distribution.
+- npm registry publication.
 - Homebrew, winget, Chocolatey, and Scoop packages.
 - GitHub Marketplace listing.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -93,4 +93,5 @@ good build; the schema accepts any non-whitespace string. `env.pass` with
 `secret: true` redacts the value from supported output sinks, and `required:
 true` fails before execution rather than mid-run when the variable is missing.
 The tradeoff is that the Docker runner adds image-pull latency on the first
-run and requires Docker on the host or runner.
+run and requires Docker on the host or runner. See `docs/DOCKER_RUNNER.md` for
+the full trust boundary and runtime model.

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,6 @@
 # Release Readiness
 
-SetupProof v0.1.0 is released through the Go module path, GitHub release
+SetupProof v0.1.1 is released through the Go module path, GitHub release
 archives, and a versioned composite GitHub Action.
 
 Before tagging a release, verify:
@@ -13,6 +13,7 @@ Before tagging a release, verify:
 - `sh scripts/check-docs.sh`
 - `sh scripts/check-examples.sh`
 - `make release-archives VERSION=<major.minor.patch>`
+- `make npm-check VERSION=<major.minor.patch>`
 - `make release-check VERSION=<major.minor.patch>`
 
 Release archive gates:
@@ -23,10 +24,24 @@ Release archive gates:
 - Each extracted binary prints the expected version with `setupproof --version`.
 - The GitHub release body includes the Go install command and the Action pin.
 
+npm package gates:
+
+- `scripts/package-npm.sh` stages a dependency-free package from the release
+  archives.
+- The package bundles Linux and macOS binaries for `amd64`/`arm64`; it does not
+  use postinstall scripts, install-time downloads, native builds, telemetry, or
+  hidden update checks.
+- `scripts/check-npm-package.sh` runs `npm pack --dry-run`, packs the tarball,
+  installs it into a clean temporary project, and verifies
+  `setupproof --version`.
+- npm install commands stay out of public install docs until the registry
+  package is published.
+
 Release automation gates:
 
 - `.github/workflows/release-checks.yml` runs the full repository gate, static
-  analysis, vulnerability scan, workflow lint, and archive verification.
+  analysis, vulnerability scan, workflow lint, archive verification, and the
+  npm packed-tarball smoke test.
 - The release checks workflow uses a patched Go toolchain for release and
   security gates rather than the oldest module language version.
 - Keep the required SetupProof workflow small and fast; add slower
@@ -55,8 +70,7 @@ Repository publication gates:
 
 Deferred distribution gates:
 
-- npm package exists and packed-tarball smoke tests pass before npm install
-  commands are documented.
+- npm registry publication exists before npm install commands are documented.
 - Homebrew, winget, Chocolatey, and Scoop packages exist before they are named
   as install options.
 - Marketplace listing must exist before Marketplace availability is advertised.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -82,7 +82,9 @@ Common causes:
 - The image tag is mutable or the digest is missing.
 
 Prefer digest-pinned images for CI. Docker improves isolation from host tooling
-drift, but it is not a security sandbox for hostile commands.
+drift, but it is not a security sandbox for hostile commands. See
+`docs/DOCKER_RUNNER.md` for the runner's workspace, network, and environment
+model.
 
 ## Missing Environment Variables
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -633,8 +633,8 @@ Fix the setup path once, in the same place contributors read it.</code></pre>
           <h2 id="final-title">Ship setup docs that still work.</h2>
           <p>Apache-2.0. No telemetry. Built for maintainers who own the README.</p>
         </div>
-        <a class="button" href="https://github.com/setupproof/setupproof/releases/tag/v0.1.0">
-          View v0.1.0
+        <a class="button" href="https://github.com/setupproof/setupproof/releases/tag/v0.1.1">
+          View v0.1.1
         </a>
       </section>
     </main>

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,11 +14,12 @@ Examples included:
 | `monorepo` | Configured multi-file example using `setupproof.yml`. | list, review, plan, execution when `npm` is available |
 | `go` | No-config path that uses root `README.md`. | list, review, plan, execution |
 | `rust` | Cargo test example with no third-party crates. | list, review, plan |
+| `failing-go` | Intentionally drifted README path (marked block points to a moved package). Demonstrates SetupProof's failure output end-to-end. | list, review, plan, execution (asserts `result=failed`) |
 
 Manual runs need the matching project toolchain. The `python-pip` example needs
 `python3`, and the `docker-compose` example needs Docker Compose.
 
 Smoke coverage lives in `scripts/check-examples.sh`. It validates all example
 Markdown with `--list`, `review`, and `--dry-run --json`, then executes the Go
-no-config example and the configured monorepo example from temporary Git
-repositories.
+no-config example, the configured monorepo example, and the failing-go example
+(asserted to fail) from temporary Git repositories.

--- a/examples/failing-go/README.md
+++ b/examples/failing-go/README.md
@@ -1,0 +1,43 @@
+# Failing Go Example
+
+This fixture shows what SetupProof reports when a marked README block has
+drifted from the project layout. It is intentionally checked in as a
+failing example so maintainers can verify SetupProof's failure output
+end-to-end, and so the docs have a concrete reference for "what does a
+real failure look like".
+
+The marked block targets `./internal/greeter`, but the package actually
+lives under `./pkg/greeter` (a common drift pattern: a contributor moves
+a package and forgets to update the README). Running the block from a
+clean checkout fails with an exit-1 from `go test`.
+
+<!-- setupproof id=failing-go-test -->
+```sh
+go test ./internal/greeter
+```
+
+## Expected output
+
+When SetupProof runs this README from a clean checkout, the marked block
+fails because the imported path does not exist. The exact line offset
+varies as this README evolves, but the result line is stable:
+
+```text
+[failed] README.md#failing-go-test file=README.md:<line> runner=local timeout=120s result=failed exit=1
+```
+
+The corresponding `go test` failure that drives `exit=1` is the standard
+"no Go files" / "package … is not in std" error.
+
+## When a maintainer would use this
+
+- Verifying SetupProof's failure path after a release-candidate change
+  to the runner or reporter.
+- Demonstrating to new contributors what a drifted README looks like
+  through the SetupProof lens, without having to break a real example.
+- Smoke coverage in `scripts/check-examples.sh` (`failing-go-test`
+  appears in `--list` / `review` / `--dry-run --json` output, and the
+  example's actual execution is asserted to produce `result=failed`).
+
+`./pkg/greeter` is the real package and has a passing unit test. The
+drift is purely in the README path.

--- a/examples/failing-go/go.mod
+++ b/examples/failing-go/go.mod
@@ -1,0 +1,3 @@
+module example.com/setupproof-failing-go
+
+go 1.22

--- a/examples/failing-go/pkg/greeter/greeter.go
+++ b/examples/failing-go/pkg/greeter/greeter.go
@@ -1,0 +1,5 @@
+package greeter
+
+func Greet(name string) string {
+	return "hello, " + name
+}

--- a/examples/failing-go/pkg/greeter/greeter_test.go
+++ b/examples/failing-go/pkg/greeter/greeter_test.go
@@ -1,0 +1,11 @@
+package greeter
+
+import "testing"
+
+func TestGreet(t *testing.T) {
+	got := Greet("world")
+	want := "hello, world"
+	if got != want {
+		t.Fatalf("Greet(world) = %q, want %q", got, want)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,4 +6,4 @@ const (
 )
 
 // Version is a var so release builds can override it with -ldflags.
-var Version = "0.1.0"
+var Version = "0.1.1"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -141,7 +141,7 @@ func TestHelpDiscoveryAliasesAndFlags(t *testing.T) {
 }
 
 func TestReportGitHubStepSummaryCommand(t *testing.T) {
-	input := `{"kind":"report","schemaVersion":"1.0.0","setupproofVersion":"0.1.0","startedAt":"2026-04-24T00:00:00Z","durationMs":7,"result":"failed","exitCode":1,"invocation":{"args":[]},"workspace":{"mode":"temporary","source":"tracked","includedUntracked":false},"runner":{"kind":"local","workspace":"temporary","networkPolicy":"host","networkEnforced":false},"files":["README.md"],"warnings":[],"blocks":[{"id":"fail","qualifiedId":"README.md#fail","file":"README.md","line":1,"language":"sh","shell":"sh","source":"false","strict":true,"stdin":"closed","tty":false,"stateMode":"shared","isolated":false,"runner":"local","timeout":"120s","timeoutMs":120000,"result":"failed","exitCode":1,"reason":"exit-code","durationMs":1,"stdoutTail":"","stderrTail":"","truncated":{"stdout":false,"stderr":false}}]}`
+	input := `{"kind":"report","schemaVersion":"1.0.0","setupproofVersion":"0.1.0","startedAt":"2026-04-24T00:00:00Z","durationMs":7,"result":"failed","exitCode":1,"invocation":{"args":[]},"workspace":{"mode":"temporary","source":"tracked","includedUntracked":false},"runner":{"kind":"local","workspace":"temporary","networkPolicy":"host","networkEnforced":false},"files":["README.md"],"warnings":[],"blocks":[{"id":"fail","qualifiedId":"README.md#fail","file":"README.md","line":1,"language":"sh","shell":"sh","source":"false","strict":true,"stdin":"closed","tty":false,"stateMode":"shared","isolated":false,"runner":"local","timeout":"120s","timeoutMs":120000,"result":"failed","exitCode":1,"reason":"exit-code","durationMs":1,"stdoutTail":"","stderrTail":"failure output\n","truncated":{"stdout":false,"stderr":false}}]}`
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
@@ -165,7 +165,7 @@ func TestReportGitHubStepSummaryCommand(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
 	}
-	for _, want := range []string{"result: failed", "Failing Blocks", "README.md#fail", "exit-code"} {
+	for _, want := range []string{"result: failed", "Failing Blocks", "README.md#fail", "README.md:1", "next command: setupproof review README.md", "failure output"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("summary missing %q:\n%s", want, stdout.String())
 		}

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -17,9 +17,9 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 	doc := string(data)
 
 	for _, want := range []string{
-		"SetupProof v0.1.0 ships as a Go module",
-		"go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.0",
-		"setupproof_0.1.0_checksums.txt",
+		"SetupProof v0.1.1 ships as a Go module",
+		"go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1",
+		"setupproof_0.1.1_checksums.txt",
 		"Native Windows execution is unsupported in v0.1",
 		"SetupProof through WSL2",
 		"PowerShell fenced blocks are unsupported in v0.1.",
@@ -53,8 +53,8 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 		"permissions:\n  contents: read",
 		"timeout-minutes: 10",
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.0",
-		"cli-version: v0.1.0",
+		"uses: setupproof/setupproof@v0.1.1",
+		"cli-version: v0.1.1",
 		"mode: review",
 		"require-blocks: \"true\"",
 	} {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -423,16 +423,13 @@ func RenderGitHubStepSummary(r *Report, opts StepSummaryOptions) string {
 	lines = append(lines,
 		"### "+title,
 		"",
-		"| Block | Result | Exit | Reason |",
-		"| --- | --- | ---: | --- |",
+		"| Block | Location | Result | Exit | Reason |",
+		"| --- | --- | --- | ---: | --- |",
 	)
 	for _, block := range selected {
-		blockID := block.QualifiedID
-		if blockID == "" {
-			blockID = block.File + "#" + block.ID
-		}
-		lines = append(lines, fmt.Sprintf("| %s | %s | %d | %s |",
-			summaryText(blockID, 160),
+		lines = append(lines, fmt.Sprintf("| %s | %s | %s | %d | %s |",
+			summaryText(summaryBlockID(block), 160),
+			summaryText(summaryLocation(block), 120),
 			summaryText(block.Result, 80),
 			block.ExitCode,
 			summaryText(block.Reason, 120),
@@ -443,10 +440,112 @@ func RenderGitHubStepSummary(r *Report, opts StepSummaryOptions) string {
 		omitted = len(r.Blocks) - len(selected)
 	}
 	if omitted > 0 {
-		lines = append(lines, fmt.Sprintf("| ... %d more |  |  |  |", omitted))
+		lines = append(lines, fmt.Sprintf("| ... %d more |  |  |  |  |", omitted))
 	}
 	lines = append(lines, "")
+	if len(failed) > 0 {
+		lines = append(lines, summaryFailureDetails(failed)...)
+	}
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func summaryFailureDetails(blocks []Block) []string {
+	selected := blocks
+	if len(selected) > 3 {
+		selected = selected[:3]
+	}
+	lines := []string{"### Failure Details", ""}
+	for _, block := range selected {
+		lines = append(lines,
+			"#### "+summaryText(summaryBlockID(block), 160),
+			"",
+			"- location: "+summaryText(summaryLocation(block), 160),
+			"- runner: "+summaryText(block.Runner, 80),
+			"- timeout: "+summaryText(block.Timeout, 80),
+			"- next command: "+summaryText(reviewCommand(block.File), 240),
+		)
+		if block.InteractiveCommand != "" {
+			lines = append(lines, "- interactive command: "+summaryText(block.InteractiveCommand, 120))
+		}
+		if strings.TrimSpace(block.Source) != "" {
+			lines = append(lines, "", "Source:", "", summaryFence("", block.Source, 1200))
+		}
+		if tail, title := summaryBestTail(block); tail != "" {
+			lines = append(lines, title+":", "", summaryFence("text", tail, 1600))
+		}
+		lines = append(lines, "")
+	}
+	if len(blocks) > len(selected) {
+		lines = append(lines, fmt.Sprintf("_%d more failing block(s) omitted from details._", len(blocks)-len(selected)), "")
+	}
+	return lines
+}
+
+func summaryBlockID(block Block) string {
+	if block.QualifiedID != "" {
+		return block.QualifiedID
+	}
+	if block.File == "" {
+		return block.ID
+	}
+	return block.File + "#" + block.ID
+}
+
+func summaryLocation(block Block) string {
+	if block.File == "" {
+		return ""
+	}
+	if block.Line <= 0 {
+		return block.File
+	}
+	return fmt.Sprintf("%s:%d", block.File, block.Line)
+}
+
+func summaryBestTail(block Block) (string, string) {
+	if strings.TrimSpace(block.StderrTail) != "" {
+		title := "Stderr tail"
+		if block.Truncated.Stderr {
+			title += " (truncated)"
+		}
+		return block.StderrTail, title
+	}
+	if strings.TrimSpace(block.StdoutTail) != "" {
+		title := "Stdout tail"
+		if block.Truncated.Stdout {
+			title += " (truncated)"
+		}
+		return block.StdoutTail, title
+	}
+	return "", ""
+}
+
+func summaryFence(info string, value string, maxRunes int) string {
+	value = summaryLog(value, maxRunes)
+	fence := markdownFence(value)
+	var builder strings.Builder
+	builder.WriteString(fence)
+	if info != "" {
+		builder.WriteString(info)
+	}
+	builder.WriteString("\n")
+	builder.WriteString(value)
+	if !strings.HasSuffix(value, "\n") {
+		builder.WriteString("\n")
+	}
+	builder.WriteString(fence)
+	return builder.String()
+}
+
+func summaryLog(value string, maxRunes int) string {
+	value = StripANSI(strings.ReplaceAll(value, "\r", ""))
+	if maxRunes <= 0 {
+		return value
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return string(runes[:maxRunes]) + "\n... truncated\n"
 }
 
 func nonPassingBlocks(blocks []Block) []Block {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -229,14 +229,31 @@ func TestRenderGitHubStepSummaryIncludesFailingBlocks(t *testing.T) {
 			ID:          "fail",
 			QualifiedID: "README.md#fail",
 			File:        "README.md",
+			Line:        12,
+			Source:      "go test ./internal/greeter",
 			Result:      "failed",
 			ExitCode:    1,
 			Reason:      "exit-code",
+			Runner:      "local",
+			Timeout:     "120s",
+			StderrTail:  "package ./internal/greeter is not in std\n",
 		}},
 	}
 
 	summary := RenderGitHubStepSummary(r, StepSummaryOptions{Mode: "run", Status: 1, ReportJSONPath: "report.json"})
-	for _, want := range []string{"result: failed", "### Failing Blocks", "README.md#fail", "exit-code"} {
+	for _, want := range []string{
+		"result: failed",
+		"### Failing Blocks",
+		"| Block | Location | Result | Exit | Reason |",
+		"README.md#fail",
+		"README.md:12",
+		"exit-code",
+		"### Failure Details",
+		"next command: setupproof review README.md",
+		"go test ./internal/greeter",
+		"Stderr tail:",
+		"package ./internal/greeter is not in std",
+	} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("summary missing %q:\n%s", want, summary)
 		}

--- a/packaging/npm/README.md.in
+++ b/packaging/npm/README.md.in
@@ -1,0 +1,10 @@
+# setupproof
+
+npm distribution wrapper for SetupProof __VERSION__.
+
+This package contains the Linux and macOS SetupProof binaries built from the
+matching GitHub release archives. It has no production dependencies, postinstall
+downloads, native builds, telemetry, or update checks.
+
+Use the repository README for current usage, safety, and CI guidance:
+https://github.com/setupproof/setupproof

--- a/packaging/npm/bin/setupproof
+++ b/packaging/npm/bin/setupproof
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const platforms = new Map([
+  ['darwin', 'darwin'],
+  ['linux', 'linux'],
+]);
+
+const arches = new Map([
+  ['arm64', 'arm64'],
+  ['x64', 'x64'],
+]);
+
+function fail(message) {
+  process.stderr.write(`setupproof npm wrapper: ${message}\n`);
+  process.exit(2);
+}
+
+const platform = platforms.get(process.platform);
+const arch = arches.get(process.arch);
+
+if (!platform || !arch) {
+  fail(`unsupported platform ${process.platform}/${process.arch}; native Windows execution is unsupported, use WSL2`);
+}
+
+const binary = path.join(__dirname, '..', 'vendor', `${platform}-${arch}`, 'setupproof');
+if (!fs.existsSync(binary)) {
+  fail(`missing bundled binary for ${platform}/${arch}`);
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' });
+if (result.error) {
+  fail(result.error.message);
+}
+
+if (result.signal) {
+  const signalExitCodes = new Map([
+    ['SIGHUP', 129],
+    ['SIGINT', 130],
+    ['SIGTERM', 143],
+  ]);
+  process.exit(signalExitCodes.get(result.signal) || 1);
+}
+
+process.exit(result.status === null ? 1 : result.status);

--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -1,0 +1,38 @@
+{
+  "name": "setupproof",
+  "version": "__VERSION__",
+  "description": "Test marked README quickstarts from a clean workspace.",
+  "license": "Apache-2.0",
+  "homepage": "https://setupproof.github.io/setupproof/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/setupproof/setupproof.git"
+  },
+  "bugs": {
+    "url": "https://github.com/setupproof/setupproof/issues"
+  },
+  "bin": {
+    "setupproof": "bin/setupproof"
+  },
+  "files": [
+    "bin/",
+    "vendor/",
+    "LICENSE",
+    "NOTICE",
+    "README.md"
+  ],
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "arm64",
+    "x64"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -12,6 +12,7 @@ $ROOT/CONTRIBUTING.md
 $ROOT/SUPPORT.md
 $ROOT/CHANGELOG.md
 $ROOT/docs/ARCHITECTURE.md
+$ROOT/docs/DOCKER_RUNNER.md
 $ROOT/docs/INSTALL.md
 $ROOT/docs/RECIPES.md
 $ROOT/docs/RELEASE_READINESS.md
@@ -67,22 +68,27 @@ assert_contains "$DOC" "<!-- ci-snippet:generic-shell -->"
 assert_contains "$DOC" "Native Windows execution is unsupported in v0.1"
 assert_contains "$DOC" "PowerShell fenced blocks are unsupported in v0.1"
 assert_contains "$DOC" "WSL2"
-assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.0"
-assert_contains "$DOC" "setupproof_0.1.0_checksums.txt"
+assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1"
+assert_contains "$DOC" "setupproof_0.1.1_checksums.txt"
 assert_contains "$DOC" "setupproof review README.md"
 assert_contains "$DOC" "setupproof --report-json setupproof-report.json --require-blocks --no-color --no-glyphs README.md"
 assert_contains "$DOC" "require-blocks: \"true\""
 assert_contains "$ROOT/LICENSE" "Apache License"
 assert_contains "$ROOT/NOTICE" "Licensed under the Apache License, Version 2.0."
 assert_contains "$ROOT/README.md" 'Apache License, Version 2.0 (`Apache-2.0`)'
-assert_contains "$ROOT/README.md" "setupproof/setupproof@v0.1.0"
+assert_contains "$ROOT/README.md" "setupproof/setupproof@v0.1.1"
 assert_contains "$ROOT/examples/node-npm/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/packages/web/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/rust/Cargo.toml" 'license = "Apache-2.0"'
 assert_contains "$ROOT/README.md" "docs/ARCHITECTURE.md"
+assert_contains "$ROOT/README.md" "docs/DOCKER_RUNNER.md"
 assert_contains "$ROOT/README.md" "docs/RECIPES.md"
 assert_contains "$ROOT/README.md" "docs/TROUBLESHOOTING.md"
+assert_contains "$ROOT/docs/DOCKER_RUNNER.md" "security sandbox"
+assert_contains "$ROOT/docs/DOCKER_RUNNER.md" "network: false"
+assert_contains "$ROOT/docs/DOCKER_RUNNER.md" "digest"
+assert_contains "$ROOT/docs/DOCKER_RUNNER.md" "env:"
 assert_contains "$ROOT/docs/RECIPES.md" "schemas/setupproof-config.schema.json"
 assert_contains "$ROOT/docs/RECIPES.md" "version: 1"
 assert_contains "$ROOT/docs/RECIPES.md" "requireBlocks: false"
@@ -108,8 +114,11 @@ assert_contains "$ROOT/docs/ARCHITECTURE.md" "Unmarked Markdown blocks never exe
 assert_contains "$ROOT/docs/ARCHITECTURE.md" "Report JSON is machine-facing output"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "Moving major Action tags"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "make release-archives"
+assert_contains "$ROOT/docs/RELEASE_READINESS.md" "make npm-check"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "make release-check"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "scripts/check-release-archives.sh"
+assert_contains "$ROOT/docs/RELEASE_READINESS.md" "scripts/check-npm-package.sh"
+assert_contains "$ROOT/docs/RELEASE_READINESS.md" "packed-tarball smoke"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "patched Go toolchain"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "CODE_OF_CONDUCT.md"
 assert_contains "$ROOT/docs/RELEASE_READINESS.md" "The SetupProof workflow is green on"

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -41,6 +41,7 @@ examples/monorepo/docs/web.md
 examples/monorepo/docs/api.md
 examples/go/README.md
 examples/rust/README.md
+examples/failing-go/README.md
 '
 
 BIN="$TMP_ROOT/setupproof"
@@ -56,7 +57,7 @@ BIN="$TMP_ROOT/setupproof"
   "$BIN" --dry-run --json --require-blocks $EXAMPLE_MARKDOWN > "$TMP_ROOT/plan.json"
 )
 
-for id in node-npm-test python-pip-test docker-compose-smoke web-package api-service go-test rust-cargo-test; do
+for id in node-npm-test python-pip-test docker-compose-smoke web-package api-service go-test rust-cargo-test failing-go-test; do
   assert_contains "$TMP_ROOT/list.txt" "id=$id"
   assert_contains "$TMP_ROOT/review.txt" "#$id"
   assert_contains "$TMP_ROOT/plan.json" "\"id\":\"$id\""
@@ -110,6 +111,19 @@ init_git_repo "$GO_EXAMPLE"
 )
 assert_contains "$TMP_ROOT/go-execution.txt" 'result=passed'
 assert_contains "$TMP_ROOT/go-execution.txt" 'README.md#go-test'
+
+FAILING_GO_EXAMPLE="$TMP_ROOT/failing-go-example"
+mkdir -p "$FAILING_GO_EXAMPLE"
+cp -R "$ROOT/examples/failing-go/." "$FAILING_GO_EXAMPLE"
+init_git_repo "$FAILING_GO_EXAMPLE"
+# This example is expected to fail; run with `|| true` so `set -e` doesn't trip
+# on the deliberate non-zero exit, then assert the failure was the one we expect.
+(
+  cd "$FAILING_GO_EXAMPLE"
+  "$BIN" --require-blocks --no-color --no-glyphs > "$TMP_ROOT/failing-go-execution.txt" || true
+)
+assert_contains "$TMP_ROOT/failing-go-execution.txt" 'result=failed'
+assert_contains "$TMP_ROOT/failing-go-execution.txt" 'README.md#failing-go-test'
 
 if command -v python3 >/dev/null 2>&1 && python3 -m venv "$TMP_ROOT/python-venv-probe" >/dev/null 2>&1; then
   PYTHON_EXAMPLE="$TMP_ROOT/python-example"

--- a/scripts/check-github-action.sh
+++ b/scripts/check-github-action.sh
@@ -121,11 +121,17 @@ if [ "${1:-}" = "report" ]; then
   printf -- '- exit code: %s\n' "${exit_code:-$status}"
   printf -- '- report JSON: `%s`\n\n' "$report_json"
   printf '### Failing Blocks\n\n'
-  printf '| Block | Result | Exit | Reason |\n'
-  printf '| --- | --- | ---: | --- |\n'
+  printf '| Block | Location | Result | Exit | Reason |\n'
+  printf '| --- | --- | --- | ---: | --- |\n'
   { printf '%s' "$report" | grep -o 'README.md#b[0-9][0-9]*' || true; } | head -n 15 | while IFS= read -r block_id; do
-    printf '| %s | failed | 1 | exit-code |\n' "$block_id"
+    printf '| %s | README.md:1 | failed | 1 | exit-code |\n' "$block_id"
   done
+  printf '\n### Failure Details\n\n'
+  printf '#### README.md#b1\n\n'
+  printf -- '- location: README.md:1\n'
+  printf -- '- runner: action-local\n'
+  printf -- '- timeout: 120s\n'
+  printf -- '- next command: setupproof review README.md\n'
   exit 0
 fi
 
@@ -301,6 +307,8 @@ test_failure_propagates_and_wraps_logs() {
 
   [ "$(cat "$dir/status")" = "1" ] || fail "action did not propagate SetupProof exit code"
   assert_contains "$dir/summary" "result: failed"
+  assert_contains "$dir/summary" "Failure Details"
+  assert_contains "$dir/summary" "next command: setupproof review README.md"
   assert_contains "$dir/stdout" "::stop-commands::"
   assert_contains "$dir/stdout" "::"
 }
@@ -461,8 +469,8 @@ test_summary_is_bounded() {
   assert_contains "$dir/summary" "Failing Blocks"
 }
 
-test_summary_fallback_without_python_keeps_block_details() {
-  local dir="$TMP_ROOT/summary-no-python"
+test_summary_renderer_keeps_block_details() {
+  local dir="$TMP_ROOT/summary-renderer"
   local fake="$dir/fake"
   mkdir -p "$dir"
   make_fake_cli "$fake"
@@ -478,7 +486,9 @@ test_summary_fallback_without_python_keeps_block_details() {
   [ "$(cat "$dir/status")" = "1" ] || fail "fallback summary run should return fake failure"
   assert_contains "$dir/summary" "Failing Blocks"
   assert_contains "$dir/summary" "README.md#b1"
+  assert_contains "$dir/summary" "README.md:1"
   assert_contains "$dir/summary" "exit-code"
+  assert_contains "$dir/summary" "next command: setupproof review README.md"
 }
 
 test_no_secret_default_workflow_shape() {
@@ -512,7 +522,7 @@ test_requires_cli_path_or_explicit_version
 test_download_and_checksum_handling
 test_rejects_unsafe_cli_version
 test_summary_is_bounded
-test_summary_fallback_without_python_keeps_block_details
+test_summary_renderer_keeps_block_details
 test_no_secret_default_workflow_shape
 
 printf 'github action checks passed\n'

--- a/scripts/check-npm-package.sh
+++ b/scripts/check-npm-package.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+  printf 'usage: scripts/check-npm-package.sh v0.1.0\n' >&2
+  exit 2
+fi
+
+case "$VERSION" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  [0-9]*.[0-9]*.[0-9]*) VERSION="v$VERSION" ;;
+  *)
+    printf 'check-npm-package: version must look like v0.1.0\n' >&2
+    exit 2
+    ;;
+esac
+
+PLAIN_VERSION="${VERSION#v}"
+PKG_ROOT="$ROOT/dist/$VERSION/npm/package"
+
+fail() {
+  printf 'check-npm-package: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v node >/dev/null 2>&1 || fail "node is required"
+command -v npm >/dev/null 2>&1 || fail "npm is required"
+
+[ -d "$PKG_ROOT" ] || "$ROOT/scripts/package-npm.sh" "$VERSION" >/dev/null
+[ -f "$PKG_ROOT/package.json" ] || fail "missing generated package.json"
+[ -f "$PKG_ROOT/vendor/manifest.json" ] || fail "missing generated binary manifest"
+
+node -e '
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (pkg.scripts && pkg.scripts.postinstall) {
+  throw new Error("postinstall scripts are not allowed");
+}
+if (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) {
+  throw new Error("production dependencies are not allowed");
+}
+' "$PKG_ROOT/package.json"
+
+version_output=$("$PKG_ROOT/bin/setupproof" --version)
+[ "$version_output" = "setupproof $PLAIN_VERSION" ] || fail "unexpected wrapper version output: $version_output"
+
+tmp="${TMPDIR:-/tmp}/setupproof-npm-check-$$"
+rm -rf "$tmp"
+mkdir -p "$tmp/project"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+npm pack "$PKG_ROOT" --dry-run --json >/dev/null
+npm pack "$PKG_ROOT" --pack-destination "$tmp" --json >/dev/null
+tarball=$(find "$tmp" -maxdepth 1 -type f -name 'setupproof-*.tgz' | head -n 1)
+[ -n "$tarball" ] || fail "npm pack did not write a tarball"
+
+(
+  cd "$tmp/project"
+  npm init -y >/dev/null
+  npm install --no-audit --no-fund "$tarball" >/dev/null
+  output=$(./node_modules/.bin/setupproof --version)
+  [ "$output" = "setupproof $PLAIN_VERSION" ] || fail "unexpected installed version output: $output"
+)
+
+printf 'npm package checks passed\n'

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -444,117 +444,12 @@ write_step_summary() {
   fi
 
   summary_tmp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/setupproof-step-summary.md"
-  if [ "${SETUPPROOF_DISABLE_PYTHON_SUMMARY:-}" != "1" ] && command -v python3 >/dev/null 2>&1; then
-    SETUPPROOF_SUMMARY_FILES="$files" SETUPPROOF_SUMMARY_LIMIT_BYTES="$summary_limit_bytes" \
-      python3 - "$mode" "$status" "$summary_report" "$report_json" > "$summary_tmp" <<'PY'
-import json
-import os
-import sys
-
-mode = sys.argv[1]
-status = int(sys.argv[2])
-summary_report = sys.argv[3]
-report_json = sys.argv[4]
-files = os.environ.get("SETUPPROOF_SUMMARY_FILES", "")
-limit = int(os.environ.get("SETUPPROOF_SUMMARY_LIMIT_BYTES", "60000"))
-
-def md(value, max_len=160):
-    text = str(value if value is not None else "")
-    text = text.replace("\r", "").replace("\n", "<br>").replace("|", "\\|")
-    if len(text) > max_len:
-        return text[: max_len - 3] + "..."
-    return text
-
-lines = ["## SetupProof", ""]
-
-if mode == "review":
-    lines.extend([
-        "- mode: review",
-        f"- exit code: {status}",
-        "- report JSON: not produced in review mode",
-        "",
-        "Review mode is non-executing.",
-    ])
-else:
-    report = None
-    if summary_report and os.path.exists(summary_report) and os.path.getsize(summary_report) > 0:
-        try:
-            with open(summary_report, "r", encoding="utf-8") as handle:
-                report = json.load(handle)
-        except Exception:
-            report = None
-
-    if not report:
-        lines.extend([
-            "- result: unavailable",
-            f"- exit code: {status}",
-            f"- report JSON: `{md(report_json, 240)}`",
-            "",
-            "SetupProof did not produce a readable JSON report.",
-        ])
-    else:
-        blocks = report.get("blocks") or []
-        warnings = report.get("warnings") or []
-        failed = [b for b in blocks if b.get("result") != "passed"]
-        selected = failed[:15] if failed else blocks[:15]
-        lines.extend([
-            f"- result: {md(report.get('result', 'unknown'))}",
-            f"- exit code: {report.get('exitCode', status)}",
-            f"- duration ms: {report.get('durationMs', 0)}",
-            f"- report JSON: `{md(report_json, 240)}`",
-            f"- files: {md(', '.join(report.get('files') or []), 240)}",
-            "",
-        ])
-        if warnings:
-            lines.append("### Warnings")
-            lines.append("")
-            for warning in warnings[:10]:
-                lines.append(f"- {md(warning, 240)}")
-            if len(warnings) > 10:
-                lines.append(f"- ... {len(warnings) - 10} more")
-            lines.append("")
-        if blocks:
-            title = "Failing Blocks" if failed else "Blocks"
-            lines.extend([
-                f"### {title}",
-                "",
-                "| Block | Result | Exit | Reason |",
-                "| --- | --- | ---: | --- |",
-            ])
-            for block in selected:
-                block_id = block.get("qualifiedId") or f"{block.get('file', '')}#{block.get('id', '')}"
-                lines.append(
-                    f"| {md(block_id)} | {md(block.get('result', 'unknown'), 80)} | "
-                    f"{block.get('exitCode', 0)} | {md(block.get('reason', ''), 120)} |"
-                )
-            omitted = len((failed if failed else blocks)) - len(selected)
-            if omitted > 0:
-                lines.append(f"| ... {omitted} more |  |  |  |")
-            lines.append("")
-        else:
-            lines.append("No marked blocks were reported.")
-            lines.append("")
-
-if files and mode != "run":
-    rendered_files = ", ".join([line for line in files.splitlines() if line])
-    lines.extend(["", f"- files: {md(rendered_files, 240)}"])
-
-text = "\n".join(lines).rstrip() + "\n"
-encoded = text.encode("utf-8")
-if len(encoded) > limit:
-    suffix = "\n\n_Summary truncated by SetupProof Action._\n"
-    cut = max(0, limit - len(suffix.encode("utf-8")))
-    text = encoded[:cut].decode("utf-8", errors="ignore").rstrip() + suffix
-sys.stdout.write(text)
-PY
-  else
-    summary_input="/dev/null"
-    if [ -n "$summary_report" ] && [ -s "$summary_report" ]; then
-      summary_input="$summary_report"
-    fi
-    if ! "$cli" report --format=github-step-summary --mode "$mode" --status "$status" --report-json "$report_json" --files "$files" < "$summary_input" > "$summary_tmp"; then
-      write_minimal_step_summary "$mode" "$status" "$report_json" > "$summary_tmp"
-    fi
+  summary_input="/dev/null"
+  if [ -n "$summary_report" ] && [ -s "$summary_report" ]; then
+    summary_input="$summary_report"
+  fi
+  if ! "$cli" report --format=github-step-summary --mode "$mode" --status "$status" --report-json "$report_json" --files "$files" < "$summary_input" > "$summary_tmp"; then
+    write_minimal_step_summary "$mode" "$status" "$report_json" > "$summary_tmp"
   fi
 
   if [ "$(wc -c < "$summary_tmp")" -gt "$summary_limit_bytes" ]; then

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+  printf 'usage: scripts/package-npm.sh v0.1.0\n' >&2
+  exit 2
+fi
+
+case "$VERSION" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  [0-9]*.[0-9]*.[0-9]*) VERSION="v$VERSION" ;;
+  *)
+    printf 'package-npm: version must look like v0.1.0\n' >&2
+    exit 2
+    ;;
+esac
+
+PLAIN_VERSION="${VERSION#v}"
+DIST="$ROOT/dist/$VERSION"
+MANIFEST="$DIST/setupproof_${PLAIN_VERSION}_checksums.txt"
+TEMPLATE="$ROOT/packaging/npm"
+PKG_ROOT="$DIST/npm/package"
+
+fail() {
+  printf 'package-npm: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -d "$DIST" ] || fail "missing release directory: $DIST"
+[ -f "$MANIFEST" ] || fail "missing checksum manifest: $MANIFEST"
+[ -f "$TEMPLATE/package.json.in" ] || fail "missing npm package template"
+
+rm -rf "$PKG_ROOT"
+mkdir -p "$PKG_ROOT/bin" "$PKG_ROOT/vendor"
+
+sed "s/__VERSION__/$PLAIN_VERSION/g" "$TEMPLATE/package.json.in" > "$PKG_ROOT/package.json"
+sed "s/__VERSION__/$PLAIN_VERSION/g" "$TEMPLATE/README.md.in" > "$PKG_ROOT/README.md"
+cp "$TEMPLATE/bin/setupproof" "$PKG_ROOT/bin/setupproof"
+cp "$ROOT/LICENSE" "$ROOT/NOTICE" "$PKG_ROOT/"
+chmod 755 "$PKG_ROOT/bin/setupproof"
+
+checksum_for() {
+  name=$1
+  awk -v name="$name" '$2 == name { print $1; found = 1 } END { if (!found) exit 1 }' "$MANIFEST"
+}
+
+copy_binary() {
+  goos=$1
+  goarch=$2
+  npm_platform=$3
+  npm_arch=$4
+  archive="setupproof_${PLAIN_VERSION}_${goos}_${goarch}.tar.gz"
+  archive_path="$DIST/$archive"
+  target_dir="$PKG_ROOT/vendor/${npm_platform}-${npm_arch}"
+  extract_dir="$DIST/npm/extract-${npm_platform}-${npm_arch}"
+
+  [ -f "$archive_path" ] || fail "missing release archive: $archive"
+  rm -rf "$extract_dir"
+  mkdir -p "$extract_dir" "$target_dir"
+  tar -xzf "$archive_path" -C "$extract_dir"
+  [ -x "$extract_dir/setupproof" ] || fail "$archive did not contain executable setupproof"
+  cp "$extract_dir/setupproof" "$target_dir/setupproof"
+  chmod 755 "$target_dir/setupproof"
+  rm -rf "$extract_dir"
+}
+
+copy_binary linux amd64 linux x64
+copy_binary linux arm64 linux arm64
+copy_binary darwin amd64 darwin x64
+copy_binary darwin arm64 darwin arm64
+
+linux_x64_archive="setupproof_${PLAIN_VERSION}_linux_amd64.tar.gz"
+linux_arm64_archive="setupproof_${PLAIN_VERSION}_linux_arm64.tar.gz"
+darwin_x64_archive="setupproof_${PLAIN_VERSION}_darwin_amd64.tar.gz"
+darwin_arm64_archive="setupproof_${PLAIN_VERSION}_darwin_arm64.tar.gz"
+
+linux_x64_sha=$(checksum_for "$linux_x64_archive") || fail "missing checksum for $linux_x64_archive"
+linux_arm64_sha=$(checksum_for "$linux_arm64_archive") || fail "missing checksum for $linux_arm64_archive"
+darwin_x64_sha=$(checksum_for "$darwin_x64_archive") || fail "missing checksum for $darwin_x64_archive"
+darwin_arm64_sha=$(checksum_for "$darwin_arm64_archive") || fail "missing checksum for $darwin_arm64_archive"
+
+cat > "$PKG_ROOT/vendor/manifest.json" <<EOF
+{
+  "version": "$PLAIN_VERSION",
+  "binaries": [
+    {
+      "platform": "linux",
+      "arch": "x64",
+      "path": "vendor/linux-x64/setupproof",
+      "archive": "$linux_x64_archive",
+      "sha256": "$linux_x64_sha"
+    },
+    {
+      "platform": "linux",
+      "arch": "arm64",
+      "path": "vendor/linux-arm64/setupproof",
+      "archive": "$linux_arm64_archive",
+      "sha256": "$linux_arm64_sha"
+    },
+    {
+      "platform": "darwin",
+      "arch": "x64",
+      "path": "vendor/darwin-x64/setupproof",
+      "archive": "$darwin_x64_archive",
+      "sha256": "$darwin_x64_sha"
+    },
+    {
+      "platform": "darwin",
+      "arch": "arm64",
+      "path": "vendor/darwin-arm64/setupproof",
+      "archive": "$darwin_arm64_archive",
+      "sha256": "$darwin_arm64_sha"
+    }
+  ]
+}
+EOF
+
+printf 'wrote %s\n' "$PKG_ROOT"


### PR DESCRIPTION
## Summary

- updates release references to v0.1.1 and carries the failing quickstart fixture from #21
- improves GitHub Action summaries with failure location, next command, source, and output-tail context
- adds npm packed-tarball release tooling and Docker runner tradeoff docs

Closes #8.
Closes #9.
Closes #11.

## Checks

- make check
- make staticcheck
- make vuln
- make actionlint
- make release-check VERSION=0.1.1

## Notes

npm registry publication is not included. Install docs still avoid npm install commands until the package is published.