### PR TITLE
Improve init workflow onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ runner, a 120 second timeout, `defaults.requireBlocks: true`, and no secret
 environment passthrough. Existing files are not overwritten unless `--force` is
 passed.
 
+Create the config and a pinned GitHub Actions workflow together:
+
+```sh
+setupproof init --workflow
+```
+
 Use non-executing inspection while adding markers:
 
 ```sh

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -32,9 +32,11 @@ CI context, while normal CLI runs default to `local`.
 ## GitHub Actions Checkout
 
 The released Action uses normal workflow checkout and downloads the pinned CLI
-archive declared by `cli-version`. The source-tree workflow remains available
-for this repository and vendored copies. ADR 0009 records the earlier bootstrap
-tradeoff and the source-tree workflow shape.
+archive declared by `cli-version`. `setupproof init --workflow` writes this
+released Action workflow for normal repositories. The source-tree workflow
+remains in this repository for dogfooding and vendored copies can adapt it
+manually. ADR 0009 records the earlier bootstrap tradeoff and the source-tree
+workflow shape.
 
 ## Shell Execution
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -45,10 +45,11 @@ checkout. Use `make release-archives VERSION=0.1.1` to build the release
 archive set locally.
 
 For a new project, `setupproof init` writes only `setupproof.yml` by default.
-Use `setupproof init --workflow` only from this source tree, or from a
-repository root that vendors the SetupProof Action files, when you want the
-source-tree workflow written too. Both writes refuse to overwrite existing
-files unless `--force` is passed.
+Use `setupproof init --workflow` to write the config and
+`.github/workflows/setupproof.yml` together for a normal GitHub repository. The
+generated workflow uses `actions/checkout@v4`, pins the SetupProof Action tag
+and `cli-version` to the current release, and passes no repository secrets.
+Both writes refuse to overwrite existing files unless `--force` is passed.
 
 `setupproof.yml` intentionally supports a small YAML subset in v0.1: two-space
 indentation, no tabs, string/number/boolean scalars, lists, and `x-` extension

--- a/docs/adr/0009-github-actions-checkout-strategy.md
+++ b/docs/adr/0009-github-actions-checkout-strategy.md
@@ -4,6 +4,8 @@ Status: Accepted
 
 Date: 2026-04-26
 
+Updated: 2026-06-26
+
 ## Context
 
 SetupProof v0.1 documents a source-tree GitHub Actions workflow before
@@ -14,10 +16,14 @@ its root, without adding secrets or default write permissions.
 The workflow needs a repository checkout before it can build
 `./cmd/setupproof` and invoke the local composite Action with `uses: ./`.
 
+As of v0.1.1, release archives and immutable Action tags exist. Normal
+repositories should use the released Action workflow instead of the source-tree
+workflow.
+
 ## Decision
 
-Use an inline `git init`/`git fetch` checkout in the source-tree workflow until
-external Action packaging exists.
+Use an inline `git init`/`git fetch` checkout in the repository-maintained
+source-tree workflow.
 
 The source-tree workflow must:
 
@@ -28,19 +34,17 @@ The source-tree workflow must:
 - build the CLI from `./cmd/setupproof`;
 - invoke the local Action with `uses: ./` and an explicit `cli-path`.
 
-`setupproof init --workflow` refuses to write this workflow unless the
-repository root contains the source-tree files the workflow needs.
+`setupproof init --workflow` generates the released Action workflow for normal
+repositories. It uses `actions/checkout@v4`, pins `setupproof/setupproof` and
+`cli-version` to the current release, and does not require source-tree Action
+files in the target repository.
 
 ## Consequences
 
 - The workflow does not depend on a third-party Action tag before SetupProof
   has its own release packaging.
 - The checkout intentionally omits LFS and submodule handling. Repositories
-  that need those features should wait for released Action documentation or
-  adapt the source-tree workflow knowingly.
-- When immutable SetupProof Action tags are published, public docs can switch
-  to the standard checkout guidance appropriate for that release channel.
-
-v0.1.0 public docs now use the released Action path. The source-tree workflow
-remains available for SetupProof itself and repositories that vendor the Action
-files intentionally.
+  that need those features should adapt the source-tree workflow knowingly.
+- Public docs and generated workflows use the released Action path.
+- The source-tree workflow remains available for SetupProof itself and
+  repositories that vendor the Action files intentionally.

--- a/internal/adoption/init.go
+++ b/internal/adoption/init.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/setupproof/setupproof/internal/app"
 	"github.com/setupproof/setupproof/internal/diag"
 	"github.com/setupproof/setupproof/internal/markdown"
 	"github.com/setupproof/setupproof/internal/planning"
@@ -39,11 +40,6 @@ func Init(req planning.Request, opts InitOptions, stdout io.Writer, stderr io.Wr
 		Data:    []byte(defaultConfig(files)),
 	})
 	if opts.Workflow {
-		if err := validateSourceTreeWorkflowRoot(resolver.Root); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 2
-		}
-		fmt.Fprintln(stderr, "warning: generated workflow is source-tree-only; use it only in this repository or a root that vendors SetupProof action files")
 		workflowPath := filepath.Join(resolver.Root, ".github", "workflows", "setupproof.yml")
 		writes = append(writes, initWrite{
 			Path:    workflowPath,
@@ -98,6 +94,7 @@ func PrintWorkflow(req planning.Request, stdout io.Writer, stderr io.Writer) int
 
 func workflowContent(files []string) string {
 	fileInput := workflowFilesInput(files)
+	actionVersion := workflowActionVersion()
 	return fmt.Sprintf(`name: SetupProof
 
 on:
@@ -114,31 +111,22 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      # Source-tree workflow: see docs/adr/0009-github-actions-checkout-strategy.md.
       - name: Checkout repository
-        shell: bash
-        run: |
-          git init .
-          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
-          git fetch --depth=1 origin "$GITHUB_SHA"
-          git checkout --detach FETCH_HEAD
-      - name: Build SetupProof CLI
-        shell: bash
-        run: go build -o "$RUNNER_TEMP/setupproof" ./cmd/setupproof
+        uses: actions/checkout@v4
       - name: Review marked quickstarts
-        uses: ./
+        uses: setupproof/setupproof@%s
         with:
-          cli-path: ${{ runner.temp }}/setupproof
+          cli-version: %s
           mode: review
           require-blocks: "true"
           files:%s
       - name: Run marked quickstarts
-        uses: ./
+        uses: setupproof/setupproof@%s
         with:
-          cli-path: ${{ runner.temp }}/setupproof
+          cli-version: %s
           require-blocks: "true"
           files:%s
-`, fileInput, fileInput)
+`, actionVersion, actionVersion, fileInput, actionVersion, actionVersion, fileInput)
 }
 
 func workflowFiles(req planning.Request) ([]string, error) {
@@ -154,27 +142,6 @@ func workflowFiles(req planning.Request) ([]string, error) {
 		files = append(files, target.Rel)
 	}
 	return files, nil
-}
-
-func validateSourceTreeWorkflowRoot(root string) error {
-	required := []string{
-		filepath.Join(root, "action.yml"),
-		filepath.Join(root, "cmd", "setupproof", "main.go"),
-		filepath.Join(root, "scripts", "github-action.sh"),
-	}
-	for _, path := range required {
-		info, err := os.Stat(path)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("init --workflow is source-tree-only until release archives exist; expected %s", filepath.ToSlash(path))
-			}
-			return err
-		}
-		if info.IsDir() {
-			return fmt.Errorf("init --workflow is source-tree-only until release archives exist; expected file %s", filepath.ToSlash(path))
-		}
-	}
-	return nil
 }
 
 type initWrite struct {
@@ -320,4 +287,12 @@ func workflowFilesInput(files []string) string {
 		builder.WriteString(file)
 	}
 	return builder.String()
+}
+
+func workflowActionVersion() string {
+	version := strings.TrimSpace(app.Version)
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -625,6 +625,7 @@ Usage:
   %s doctor <markdown files...>
   %s init [--force] [markdown files...]
   %s init --check
+  %s init --workflow [--force] [markdown files...]
   %s init --workflow --print
   %s report --format=github-step-summary
   %s --help
@@ -646,6 +647,6 @@ Flags:
   --no-glyphs              Use text status labels instead of symbols.
 
 SetupProof supports local, action-local, and Docker runners with terminal, Markdown, and JSON execution reports.
-`, app.DisplayName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName)
+`, app.DisplayName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName, app.CommandName)
 	_, _ = stdout.Write(buffer.Bytes())
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -731,12 +731,11 @@ func TestInitWorkflowPrintsConservativeWorkflowOnly(t *testing.T) {
 		"pull_request:",
 		"permissions:\n  contents: read",
 		"runs-on: ubuntu-24.04",
-		"docs/adr/0009-github-actions-checkout-strategy.md",
-		"go build -o \"$RUNNER_TEMP/setupproof\" ./cmd/setupproof",
-		"uses: ./",
+		"uses: actions/checkout@v4",
+		"uses: setupproof/setupproof@v0.1.1",
+		"cli-version: v0.1.1",
 		"mode: review",
 		"require-blocks: \"true\"",
-		"cli-path: ${{ runner.temp }}/setupproof",
 		"files: |\n            README.md",
 	} {
 		if !strings.Contains(output, want) {
@@ -749,6 +748,16 @@ func TestInitWorkflowPrintsConservativeWorkflowOnly(t *testing.T) {
 	if strings.Contains(output, "github.token") {
 		t.Fatalf("workflow should not depend on the default token:\n%s", output)
 	}
+	for _, forbidden := range []string{
+		"go build -o",
+		"uses: ./",
+		"cli-path:",
+		"source-tree",
+	} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("workflow output contains source-tree detail %q:\n%s", forbidden, output)
+		}
+	}
 	if _, err := os.Stat("setupproof.yml"); !os.IsNotExist(err) {
 		t.Fatalf("init --workflow --print wrote config: %v", err)
 	}
@@ -757,28 +766,47 @@ func TestInitWorkflowPrintsConservativeWorkflowOnly(t *testing.T) {
 	}
 }
 
-func TestInitWorkflowRejectsDownstreamRoot(t *testing.T) {
+func TestInitWorkflowWritesExternalRepoWorkflow(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := Run([]string{"init", "--workflow"}, &stdout, &stderr)
-	if code != 2 {
-		t.Fatalf("exit code = %d", code)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "init --workflow is source-tree-only") {
+	if stderr.String() != "" {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
-	if _, err := os.Stat("setupproof.yml"); !os.IsNotExist(err) {
-		t.Fatalf("init wrote config after workflow root check failed: %v", err)
+	if !strings.Contains(stdout.String(), "wrote setupproof.yml") || !strings.Contains(stdout.String(), "wrote .github/workflows/setupproof.yml") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	workflow := readCLIFile(t, filepath.Join(dir, ".github", "workflows", "setupproof.yml"))
+	for _, want := range []string{
+		"uses: actions/checkout@v4",
+		"uses: setupproof/setupproof@v0.1.1",
+		"cli-version: v0.1.1",
+		"require-blocks: \"true\"",
+		"files: |\n            README.md",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("workflow missing %q:\n%s", want, workflow)
+		}
+	}
+	for _, forbidden := range []string{"go build -o", "uses: ./", "cli-path:", "source-tree"} {
+		if strings.Contains(workflow, forbidden) {
+			t.Fatalf("workflow contains source-tree detail %q:\n%s", forbidden, workflow)
+		}
+	}
+	if config := readCLIFile(t, filepath.Join(dir, "setupproof.yml")); !strings.Contains(config, "  - README.md\n") {
+		t.Fatalf("config missing default file:\n%s", config)
 	}
 }
 
 func TestInitWorkflowWritesOnlyWhenRequestedAndPreflightsOverwrites(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
-	writeSourceTreeWorkflowFixture(t, dir)
 	if err := os.MkdirAll(filepath.Join(".github", "workflows"), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -812,19 +840,12 @@ func TestInitWorkflowWritesOnlyWhenRequestedAndPreflightsOverwrites(t *testing.T
 	if !strings.Contains(readCLIFile(t, workflowPath), "require-blocks: \"true\"") {
 		t.Fatalf("workflow missing explicit require-blocks:\n%s", readCLIFile(t, workflowPath))
 	}
-	if !strings.Contains(stderr.String(), "generated workflow is source-tree-only") {
+	if stderr.String() != "" {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "wrote setupproof.yml") || !strings.Contains(stdout.String(), "wrote .github/workflows/setupproof.yml") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
-}
-
-func writeSourceTreeWorkflowFixture(t *testing.T, root string) {
-	t.Helper()
-	writeCLIFile(t, root, "action.yml", "name: SetupProof\n")
-	writeCLIFile(t, root, filepath.Join("cmd", "setupproof", "main.go"), "package main\n")
-	writeCLIFile(t, root, filepath.Join("scripts", "github-action.sh"), "#!/usr/bin/env bash\n")
 }
 
 func chdir(t *testing.T, dir string) {


### PR DESCRIPTION
## Summary
- generate the released Action workflow from `setupproof init --workflow` for normal repositories
- keep workflow and config writes preflighted and pinned to the current release
- update help, docs, and tests around external-repository onboarding

## Checks
- `go test ./internal/cli ./internal/adoption`
- `sh scripts/check-docs.sh`
- `make check`
- `make staticcheck`
- `make vuln`
- `make actionlint`
- `make release-check`