### PR TITLE
Prepare v0.1.2 release

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run workflow lint
         run: make actionlint
       - name: Verify release archives
-        run: make release-check VERSION=0.1.1
+        run: make release-check VERSION=0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.2 - 2026-06-27
+
+- Changed `setupproof init --workflow` to generate the released Action
+  workflow for normal repositories.
+- Pinned generated workflows to the current Action tag and matching
+  `cli-version`.
+- Updated onboarding docs and tests for external repository setup.
+
 ## 0.1.1 - 2026-06-26
 
 - Added a failing Go fixture that demonstrates README drift detection.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.1.1
+VERSION ?= 0.1.2
 LDFLAGS := -X github.com/setupproof/setupproof/internal/app.Version=$(VERSION)
 STATICCHECK_VERSION ?= v0.6.1
 GOVULNCHECK_VERSION ?= v1.1.4

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ are exactly the failures SetupProof makes visible.
 Prerequisites: Go 1.22 or newer, Git, and a POSIX shell.
 
 ```sh
-go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1
+go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2
 setupproof --version
 ```
 
@@ -140,15 +140,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: setupproof/setupproof@v0.1.1
+      - uses: setupproof/setupproof@v0.1.2
         with:
-          cli-version: v0.1.1
+          cli-version: v0.1.2
           mode: review
           require-blocks: "true"
           files: README.md
-      - uses: setupproof/setupproof@v0.1.1
+      - uses: setupproof/setupproof@v0.1.2
         with:
-          cli-version: v0.1.1
+          cli-version: v0.1.2
           require-blocks: "true"
           files: README.md
 ```

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -6,7 +6,7 @@ in `docs/adr/`.
 ## Runtime
 
 SetupProof uses a Go CLI. The GitHub Action is a composite Action that invokes
-the CLI. v0.1.1 is distributed through `go install`, GitHub release archives,
+the CLI. v0.1.2 is distributed through `go install`, GitHub release archives,
 and a pinned composite Action. The release tooling also stages and smoke-tests
 an npm tarball; npm registry publication and operating-system package managers
 remain deferred until those packages exist.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,6 +1,6 @@
 # Install And CI
 
-SetupProof v0.1.1 ships as a Go module, GitHub release archives, and a
+SetupProof v0.1.2 ships as a Go module, GitHub release archives, and a
 versioned composite GitHub Action. npm registry, Homebrew, winget, Chocolatey,
 and Scoop packages are not published yet.
 
@@ -9,7 +9,7 @@ and Scoop packages are not published yet.
 Prerequisites: Go 1.22 or newer, Git, and a POSIX shell.
 
 ```sh
-go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1
+go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2
 setupproof --version
 setupproof review README.md
 setupproof --require-blocks --no-color --no-glyphs README.md
@@ -23,11 +23,11 @@ archive with the matching checksum manifest before running it.
 
 Archive names:
 
-- `setupproof_0.1.1_linux_amd64.tar.gz`
-- `setupproof_0.1.1_linux_arm64.tar.gz`
-- `setupproof_0.1.1_darwin_amd64.tar.gz`
-- `setupproof_0.1.1_darwin_arm64.tar.gz`
-- `setupproof_0.1.1_checksums.txt`
+- `setupproof_0.1.2_linux_amd64.tar.gz`
+- `setupproof_0.1.2_linux_arm64.tar.gz`
+- `setupproof_0.1.2_darwin_amd64.tar.gz`
+- `setupproof_0.1.2_darwin_arm64.tar.gz`
+- `setupproof_0.1.2_checksums.txt`
 
 ## Source Checkout
 
@@ -41,7 +41,7 @@ make build
 ```
 
 Use `make build VERSION=<tag>` when building a release binary from a tagged
-checkout. Use `make release-archives VERSION=0.1.1` to build the release
+checkout. Use `make release-archives VERSION=0.1.2` to build the release
 archive set locally.
 
 For a new project, `setupproof init` writes only `setupproof.yml` by default.
@@ -84,15 +84,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: setupproof/setupproof@v0.1.1
+      - uses: setupproof/setupproof@v0.1.2
         with:
-          cli-version: v0.1.1
+          cli-version: v0.1.2
           mode: review
           require-blocks: "true"
           files: README.md
-      - uses: setupproof/setupproof@v0.1.1
+      - uses: setupproof/setupproof@v0.1.2
         with:
-          cli-version: v0.1.1
+          cli-version: v0.1.2
           require-blocks: "true"
           files: README.md
 ```
@@ -188,11 +188,11 @@ blocks.
 
 ## Distribution Status
 
-Published for v0.1.1:
+Published for v0.1.2:
 
 - Go install from the public module path.
 - Linux and macOS release archives with checksums.
-- Versioned GitHub Action usage with `cli-version: v0.1.1`.
+- Versioned GitHub Action usage with `cli-version: v0.1.2`.
 
 Deferred until implemented and verified:
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,6 @@
 # Release Readiness
 
-SetupProof v0.1.1 is released through the Go module path, GitHub release
+SetupProof v0.1.2 is released through the Go module path, GitHub release
 archives, and a versioned composite GitHub Action.
 
 Before tagging a release, verify:

--- a/docs/index.html
+++ b/docs/index.html
@@ -633,8 +633,8 @@ Fix the setup path once, in the same place contributors read it.</code></pre>
           <h2 id="final-title">Ship setup docs that still work.</h2>
           <p>Apache-2.0. No telemetry. Built for maintainers who own the README.</p>
         </div>
-        <a class="button" href="https://github.com/setupproof/setupproof/releases/tag/v0.1.1">
-          View v0.1.1
+        <a class="button" href="https://github.com/setupproof/setupproof/releases/tag/v0.1.2">
+          View v0.1.2
         </a>
       </section>
     </main>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,4 +6,4 @@ const (
 )
 
 // Version is a var so release builds can override it with -ldflags.
-var Version = "0.1.1"
+var Version = "0.1.2"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -732,8 +732,8 @@ func TestInitWorkflowPrintsConservativeWorkflowOnly(t *testing.T) {
 		"permissions:\n  contents: read",
 		"runs-on: ubuntu-24.04",
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.1",
-		"cli-version: v0.1.1",
+		"uses: setupproof/setupproof@v0.1.2",
+		"cli-version: v0.1.2",
 		"mode: review",
 		"require-blocks: \"true\"",
 		"files: |\n            README.md",
@@ -785,8 +785,8 @@ func TestInitWorkflowWritesExternalRepoWorkflow(t *testing.T) {
 	workflow := readCLIFile(t, filepath.Join(dir, ".github", "workflows", "setupproof.yml"))
 	for _, want := range []string{
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.1",
-		"cli-version: v0.1.1",
+		"uses: setupproof/setupproof@v0.1.2",
+		"cli-version: v0.1.2",
 		"require-blocks: \"true\"",
 		"files: |\n            README.md",
 	} {

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -17,9 +17,9 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 	doc := string(data)
 
 	for _, want := range []string{
-		"SetupProof v0.1.1 ships as a Go module",
-		"go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1",
-		"setupproof_0.1.1_checksums.txt",
+		"SetupProof v0.1.2 ships as a Go module",
+		"go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2",
+		"setupproof_0.1.2_checksums.txt",
 		"Native Windows execution is unsupported in v0.1",
 		"SetupProof through WSL2",
 		"PowerShell fenced blocks are unsupported in v0.1.",
@@ -53,8 +53,8 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 		"permissions:\n  contents: read",
 		"timeout-minutes: 10",
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.1",
-		"cli-version: v0.1.1",
+		"uses: setupproof/setupproof@v0.1.2",
+		"cli-version: v0.1.2",
 		"mode: review",
 		"require-blocks: \"true\"",
 	} {

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -68,15 +68,15 @@ assert_contains "$DOC" "<!-- ci-snippet:generic-shell -->"
 assert_contains "$DOC" "Native Windows execution is unsupported in v0.1"
 assert_contains "$DOC" "PowerShell fenced blocks are unsupported in v0.1"
 assert_contains "$DOC" "WSL2"
-assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.1"
-assert_contains "$DOC" "setupproof_0.1.1_checksums.txt"
+assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2"
+assert_contains "$DOC" "setupproof_0.1.2_checksums.txt"
 assert_contains "$DOC" "setupproof review README.md"
 assert_contains "$DOC" "setupproof --report-json setupproof-report.json --require-blocks --no-color --no-glyphs README.md"
 assert_contains "$DOC" "require-blocks: \"true\""
 assert_contains "$ROOT/LICENSE" "Apache License"
 assert_contains "$ROOT/NOTICE" "Licensed under the Apache License, Version 2.0."
 assert_contains "$ROOT/README.md" 'Apache License, Version 2.0 (`Apache-2.0`)'
-assert_contains "$ROOT/README.md" "setupproof/setupproof@v0.1.1"
+assert_contains "$ROOT/README.md" "setupproof/setupproof@v0.1.2"
 assert_contains "$ROOT/examples/node-npm/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/packages/web/package.json" '"license": "Apache-2.0"'


### PR DESCRIPTION
## Summary
- bump release-facing version references to v0.1.2
- add the v0.1.2 changelog entry
- update release checks and docs assertions for the new release

## Checks
- `go test ./internal/cli ./internal/adoption`
- `sh scripts/check-docs.sh`
- `git diff --check`
- `make check`
- `make staticcheck`
- `make vuln`
- `make actionlint`
- `make release-check VERSION=0.1.2`
- `make fmt-check`
- `./setupproof --version`
- `./setupproof init --workflow --print`