### PR TITLE
Reject duplicate config keys

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -53,8 +53,8 @@ Both writes refuse to overwrite existing files unless `--force` is passed.
 
 `setupproof.yml` intentionally supports a small YAML subset in v0.1: two-space
 indentation, no tabs, string/number/boolean scalars, lists, and `x-` extension
-keys. The parser rejects unsupported YAML forms with precise errors instead of
-silently guessing.
+keys. Duplicate keys and unsupported YAML forms are rejected with precise
+errors instead of silently guessing.
 
 ## GitHub Actions
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,11 +67,16 @@ func Parse(contents []byte) (*Config, error) {
 }
 
 type yamlParser struct {
-	cfg        Config
-	section    string
-	subsection string
-	block      *Block
-	pass       *EnvPass
+	cfg          Config
+	section      string
+	subsection   string
+	block        *Block
+	pass         *EnvPass
+	topLevelKeys map[string]bool
+	defaultKeys  map[string]bool
+	envKeys      map[string]bool
+	blockKeys    map[string]bool
+	passKeys     map[string]bool
 }
 
 func (p *yamlParser) parse(contents string) (*Config, error) {
@@ -153,6 +158,9 @@ func (p *yamlParser) parseTopLevel(lineNo int, text string) error {
 
 	switch key {
 	case "version":
+		if err := claimConfigKey(&p.topLevelKeys, lineNo, "top-level", key); err != nil {
+			return err
+		}
 		if value == "" {
 			return fmt.Errorf("line %d: version requires a value", lineNo)
 		}
@@ -162,12 +170,18 @@ func (p *yamlParser) parseTopLevel(lineNo int, text string) error {
 		}
 		p.cfg.Version = version
 	case "defaults", "files", "env", "blocks":
+		if err := claimConfigKey(&p.topLevelKeys, lineNo, "top-level", key); err != nil {
+			return err
+		}
 		if value != "" {
 			return fmt.Errorf("line %d: %s must be a section", lineNo, key)
 		}
 		p.section = key
 	default:
 		if strings.HasPrefix(key, "x-") {
+			if err := claimConfigKey(&p.topLevelKeys, lineNo, "top-level", key); err != nil {
+				return err
+			}
 			p.section = "x"
 			return nil
 		}
@@ -183,6 +197,9 @@ func (p *yamlParser) parseDefaults(lineNo int, text string) error {
 	key, value, ok := keyValue(text)
 	if !ok || value == "" {
 		return fmt.Errorf("line %d: defaults field requires key: value", lineNo)
+	}
+	if err := claimConfigKey(&p.defaultKeys, lineNo, "defaults", key); err != nil {
+		return err
 	}
 	switch key {
 	case "runner":
@@ -229,8 +246,12 @@ func (p *yamlParser) parseEnv(lineNo int, indent int, text string) error {
 		}
 		switch key {
 		case "allow", "pass":
+			if err := claimConfigKey(&p.envKeys, lineNo, "env", key); err != nil {
+				return err
+			}
 			p.subsection = key
 			p.pass = nil
+			p.passKeys = nil
 			return nil
 		default:
 			return fmt.Errorf("line %d: unknown env field %q", lineNo, key)
@@ -257,8 +278,9 @@ func (p *yamlParser) parseEnv(lineNo int, indent int, text string) error {
 				return fmt.Errorf("line %d: env.pass entries must be list items", lineNo)
 			}
 			pass := EnvPass{}
+			p.passKeys = nil
 			if value != "" {
-				if err := assignEnvPass(&pass, lineNo, value); err != nil {
+				if err := assignEnvPass(&pass, lineNo, value, &p.passKeys); err != nil {
 					return err
 				}
 			}
@@ -269,7 +291,7 @@ func (p *yamlParser) parseEnv(lineNo int, indent int, text string) error {
 		if indent != 6 || p.pass == nil {
 			return fmt.Errorf("line %d: env.pass fields must use six-space indentation", lineNo)
 		}
-		return assignEnvPass(p.pass, lineNo, text)
+		return assignEnvPass(p.pass, lineNo, text, &p.passKeys)
 	}
 	return nil
 }
@@ -284,8 +306,9 @@ func (p *yamlParser) parseBlocks(lineNo int, indent int, text string) error {
 			return fmt.Errorf("line %d: blocks entries must be list items", lineNo)
 		}
 		block := Block{}
+		p.blockKeys = nil
 		if value != "" {
-			if err := assignBlock(&block, lineNo, value); err != nil {
+			if err := assignBlock(&block, lineNo, value, &p.blockKeys); err != nil {
 				return err
 			}
 		}
@@ -297,13 +320,16 @@ func (p *yamlParser) parseBlocks(lineNo int, indent int, text string) error {
 	if indent != 4 || p.block == nil {
 		return fmt.Errorf("line %d: block fields must use four-space indentation", lineNo)
 	}
-	return assignBlock(p.block, lineNo, text)
+	return assignBlock(p.block, lineNo, text, &p.blockKeys)
 }
 
-func assignEnvPass(pass *EnvPass, lineNo int, text string) error {
+func assignEnvPass(pass *EnvPass, lineNo int, text string, seen *map[string]bool) error {
 	key, value, ok := keyValue(text)
 	if !ok || value == "" {
 		return fmt.Errorf("line %d: env.pass field requires key: value", lineNo)
+	}
+	if err := claimConfigKey(seen, lineNo, "env.pass", key); err != nil {
+		return err
 	}
 	switch key {
 	case "name":
@@ -326,10 +352,13 @@ func assignEnvPass(pass *EnvPass, lineNo int, text string) error {
 	return nil
 }
 
-func assignBlock(block *Block, lineNo int, text string) error {
+func assignBlock(block *Block, lineNo int, text string, seen *map[string]bool) error {
 	key, value, ok := keyValue(text)
 	if !ok || value == "" {
 		return fmt.Errorf("line %d: block field requires key: value", lineNo)
+	}
+	if err := claimConfigKey(seen, lineNo, "block", key); err != nil {
+		return err
 	}
 	switch key {
 	case "file":
@@ -363,6 +392,17 @@ func assignBlock(block *Block, lineNo int, text string) error {
 	default:
 		return fmt.Errorf("line %d: unknown block field %q", lineNo, key)
 	}
+	return nil
+}
+
+func claimConfigKey(seen *map[string]bool, lineNo int, scope string, key string) error {
+	if *seen == nil {
+		*seen = make(map[string]bool)
+	}
+	if (*seen)[key] {
+		return fmt.Errorf("line %d: duplicate %s field %q", lineNo, scope, key)
+	}
+	(*seen)[key] = true
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,6 +98,52 @@ func TestParseRejectsInvalidBoolean(t *testing.T) {
 	}
 }
 
+func TestParseRejectsDuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{
+			name: "top-level",
+			doc:  "version: 1\nversion: 1\n",
+			want: `duplicate top-level field "version"`,
+		},
+		{
+			name: "defaults",
+			doc:  "version: 1\ndefaults:\n  runner: local\n  runner: docker\n",
+			want: `duplicate defaults field "runner"`,
+		},
+		{
+			name: "env",
+			doc:  "version: 1\nenv:\n  allow:\n    - NODE_ENV\n  allow:\n    - CI\n",
+			want: `duplicate env field "allow"`,
+		},
+		{
+			name: "env-pass",
+			doc:  "version: 1\nenv:\n  pass:\n    - name: TOKEN\n      name: OTHER_TOKEN\n",
+			want: `duplicate env.pass field "name"`,
+		},
+		{
+			name: "block",
+			doc:  "version: 1\nblocks:\n  - file: README.md\n    file: docs/setup.md\n    id: quickstart\n",
+			want: `duplicate block field "file"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.doc))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseRejectsDefaultsListWithSpecificError(t *testing.T) {
 	_, err := Parse([]byte("version: 1\ndefaults:\n  - runner: local\n"))
 	if err == nil {

--- a/schemas/setupproof-config.schema.json
+++ b/schemas/setupproof-config.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "SetupProof Config",
-  "description": "Schema for setupproof.yml. The v0.1 parser supports a small YAML subset: two-space indentation, no tabs, string/number/boolean scalars, lists, and x- extension keys.",
+  "description": "Schema for setupproof.yml. The v0.1 parser supports a small YAML subset: two-space indentation, no tabs, string/number/boolean scalars, lists, no duplicate keys, and x- extension keys.",
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {


### PR DESCRIPTION
## Summary
- reject duplicate fields in `setupproof.yml` sections instead of silently overriding them
- cover duplicate top-level, defaults, env, env.pass, and block fields with parser tests
- document the stricter config subset in install docs and the config schema description

## Checks
- `go test ./...`
- `go test ./internal/config ./internal/cli`
- `go test -race ./...`
- `sh scripts/check-docs.sh`
- `make check`
- `make release-check VERSION=0.1.2`
- `make fmt-check`
- `make staticcheck`
- `make vuln`
- `make actionlint`