### PR TITLE
Use neutral Dependabot timezone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
-      timezone: America/New_York
+      timezone: Etc/UTC
     open-pull-requests-limit: 5
     labels:
       - enhancement
@@ -21,7 +21,7 @@ updates:
       interval: weekly
       day: monday
       time: "09:15"
-      timezone: America/New_York
+      timezone: Etc/UTC
     open-pull-requests-limit: 5
     labels:
       - enhancement


### PR DESCRIPTION
## Summary
- switch Dependabot schedules from a regional timezone to UTC
- keep the existing update cadence and grouping unchanged
- reduce unnecessary maintainer-location signal in tracked public config

## Checks
- `sh scripts/check-foundation.sh`
- `make check`
- `make actionlint`
- `make staticcheck`
- `make vuln`
- `git diff --check`
- tracked-file provenance and privacy scans