### PR TITLE
Prepare v0.1.3 release

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run workflow lint
         run: make actionlint
       - name: Verify release archives
-        run: make release-check VERSION=0.1.2
+        run: make release-check VERSION=0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.3 - 2026-07-03
+
+- Updated public repository and Action metadata for distribution channels.
+- Refreshed npm package metadata for registry publication readiness.
+- Updated release documentation for the current distribution baseline.
+
 ## 0.1.2 - 2026-06-27
 
 - Changed `setupproof init --workflow` to generate the released Action

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.1.2
+VERSION ?= 0.1.3
 LDFLAGS := -X github.com/setupproof/setupproof/internal/app.Version=$(VERSION)
 STATICCHECK_VERSION ?= v0.6.1
 GOVULNCHECK_VERSION ?= v1.1.4

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ are exactly the failures SetupProof makes visible.
 Prerequisites: Go 1.22 or newer, Git, and a POSIX shell.
 
 ```sh
-go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2
+go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3
 setupproof --version
 ```
 
@@ -164,15 +164,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: setupproof/setupproof@v0.1.2
+      - uses: setupproof/setupproof@v0.1.3
         with:
-          cli-version: v0.1.2
+          cli-version: v0.1.3
           mode: review
           require-blocks: "true"
           files: README.md
-      - uses: setupproof/setupproof@v0.1.2
+      - uses: setupproof/setupproof@v0.1.3
         with:
-          cli-version: v0.1.2
+          cli-version: v0.1.3
           require-blocks: "true"
           files: README.md
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,8 @@
 # Security
 
-SetupProof v0.1 runs from this source tree. Packaged installs and external
-Action tag examples are not published yet.
+SetupProof v0.1 is distributed through the Go module path, GitHub release
+archives, source checkouts, and versioned GitHub Action tags. Other package
+manager paths are documented only after they are published and verified.
 
 ## Reporting Security Issues
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support
 
-SetupProof v0.1.2 can run from the Go module install path, release archives, a
+SetupProof v0.1.3 can run from the Go module install path, release archives, a
 source checkout, or the pinned GitHub Action.
 
 For help with a run, include enough context to identify the marked block and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -6,7 +6,7 @@ in `docs/adr/`.
 ## Runtime
 
 SetupProof uses a Go CLI. The GitHub Action is a composite Action that invokes
-the CLI. v0.1.2 is distributed through `go install`, GitHub release archives,
+the CLI. v0.1.3 is distributed through `go install`, GitHub release archives,
 and a pinned composite Action. The release tooling also stages and smoke-tests
 an npm tarball; npm registry publication and operating-system package managers
 remain deferred until those packages exist.
@@ -64,6 +64,6 @@ an immutable public URL for released schemas.
 
 ## Marketplace
 
-GitHub Marketplace listing is deferred for v0.1. The main product repository
-remains the source of truth until current Marketplace requirements are checked
-against the repository strategy.
+GitHub Marketplace listing is planned from the main product repository using
+the root `action.yml`. Public docs do not advertise Marketplace availability
+until the listing exists. ADR 0008 records the repository strategy and fallback.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,7 @@
 # Install And CI
 
 Install the CLI when you want to verify marked README setup blocks locally or
-in CI. SetupProof v0.1.2 ships as a Go module, GitHub release archives, and a
+in CI. SetupProof v0.1.3 ships as a Go module, GitHub release archives, and a
 versioned composite GitHub Action. npm registry, Homebrew, winget, Chocolatey,
 and Scoop packages are not published yet.
 
@@ -10,7 +10,7 @@ and Scoop packages are not published yet.
 Prerequisites: Go 1.22 or newer, Git, and a POSIX shell.
 
 ```sh
-go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2
+go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3
 setupproof --version
 setupproof review README.md
 setupproof --require-blocks --no-color --no-glyphs README.md
@@ -24,11 +24,11 @@ archive with the matching checksum manifest before running it.
 
 Archive names:
 
-- `setupproof_0.1.2_linux_amd64.tar.gz`
-- `setupproof_0.1.2_linux_arm64.tar.gz`
-- `setupproof_0.1.2_darwin_amd64.tar.gz`
-- `setupproof_0.1.2_darwin_arm64.tar.gz`
-- `setupproof_0.1.2_checksums.txt`
+- `setupproof_0.1.3_linux_amd64.tar.gz`
+- `setupproof_0.1.3_linux_arm64.tar.gz`
+- `setupproof_0.1.3_darwin_amd64.tar.gz`
+- `setupproof_0.1.3_darwin_arm64.tar.gz`
+- `setupproof_0.1.3_checksums.txt`
 
 ## Source Checkout
 
@@ -42,7 +42,7 @@ make build
 ```
 
 Use `make build VERSION=<tag>` when building a release binary from a tagged
-checkout. Use `make release-archives VERSION=0.1.2` to build the release
+checkout. Use `make release-archives VERSION=0.1.3` to build the release
 archive set locally.
 
 For a new project, `setupproof init` writes only `setupproof.yml` by default.
@@ -85,15 +85,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: setupproof/setupproof@v0.1.2
+      - uses: setupproof/setupproof@v0.1.3
         with:
-          cli-version: v0.1.2
+          cli-version: v0.1.3
           mode: review
           require-blocks: "true"
           files: README.md
-      - uses: setupproof/setupproof@v0.1.2
+      - uses: setupproof/setupproof@v0.1.3
         with:
-          cli-version: v0.1.2
+          cli-version: v0.1.3
           require-blocks: "true"
           files: README.md
 ```
@@ -189,11 +189,11 @@ blocks.
 
 ## Distribution Status
 
-Published for v0.1.2:
+Published for v0.1.3:
 
 - Go install from the public module path.
 - Linux and macOS release archives with checksums.
-- Versioned GitHub Action usage with `cli-version: v0.1.2`.
+- Versioned GitHub Action usage with `cli-version: v0.1.3`.
 
 Deferred until implemented and verified:
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,6 @@
 # Release Readiness
 
-SetupProof v0.1.2 is released through the Go module path, GitHub release
+SetupProof v0.1.3 is released through the Go module path, GitHub release
 archives, and a versioned composite GitHub Action.
 
 Before tagging a release, verify:

--- a/docs/adr/0008-marketplace-strategy.md
+++ b/docs/adr/0008-marketplace-strategy.md
@@ -1,34 +1,35 @@
-# ADR 0008: Marketplace Deferral And Repository Strategy
+# ADR 0008: Marketplace Listing Strategy
 
 Status: Accepted
 
 Date: 2026-04-24
+Updated: 2026-07-03
 
 ## Context
 
 SetupProof should dogfood its own workflows and keep release automation in the
-main repository. GitHub Marketplace repository-shape requirements may conflict
-with that layout.
+main repository. Earlier v0.1 planning deferred Marketplace listing until the
+current repository-shape requirements were checked against that layout.
 
 ## Decision
 
-Defer GitHub Marketplace listing for v0.1.
+List the existing public repository on GitHub Marketplace from the next release
+that includes current Action metadata.
 
 Repository strategy:
 
 - Keep the product, CLI source, docs, workflows, and Action packaging in the
-  main repository through v0.1.
-- Do not advertise Marketplace availability until current Marketplace
-  requirements are checked and the listing exists.
-- Do not create a separate Action-only repository unless Marketplace rules make
-  it necessary.
-- If Marketplace still requires an action-only repository with no workflow
-  files, choose between continued deferral and a separate Action repository in a
-  later ADR.
+  main repository.
+- Use the single root `action.yml` as the Marketplace action metadata file.
+- Do not advertise Marketplace availability until the listing exists.
+- Do not create a separate Action-only repository unless GitHub rejects the
+  main repository listing.
 
 ## Consequences
 
-- A usable Action may ship without making Marketplace a release blocker.
+- A usable Action may ship before Marketplace listing is complete.
 - Public docs must not imply Marketplace availability before it exists.
 - The main repository can keep CI workflows needed for dogfooding and release
   checks.
+- If GitHub blocks listing because of repository shape or account requirements,
+  record the blocker here before changing repository strategy.

--- a/docs/index.html
+++ b/docs/index.html
@@ -684,8 +684,8 @@ npm test
           <h2 id="final-title">Ship setup docs that still work.</h2>
           <p>Apache-2.0. No telemetry. Built for maintainers who own the README.</p>
         </div>
-        <a class="button" href="https://github.com/setupproof/setupproof/releases/tag/v0.1.2">
-          View v0.1.2
+        <a class="button" href="https://github.com/setupproof/setupproof/releases/tag/v0.1.3">
+          View v0.1.3
         </a>
       </section>
     </main>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,4 +6,4 @@ const (
 )
 
 // Version is a var so release builds can override it with -ldflags.
-var Version = "0.1.2"
+var Version = "0.1.3"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -757,8 +757,8 @@ func TestInitWorkflowPrintsConservativeWorkflowOnly(t *testing.T) {
 		"permissions:\n  contents: read",
 		"runs-on: ubuntu-24.04",
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.2",
-		"cli-version: v0.1.2",
+		"uses: setupproof/setupproof@v0.1.3",
+		"cli-version: v0.1.3",
 		"mode: review",
 		"require-blocks: \"true\"",
 		"files: |\n            README.md",
@@ -810,8 +810,8 @@ func TestInitWorkflowWritesExternalRepoWorkflow(t *testing.T) {
 	workflow := readCLIFile(t, filepath.Join(dir, ".github", "workflows", "setupproof.yml"))
 	for _, want := range []string{
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.2",
-		"cli-version: v0.1.2",
+		"uses: setupproof/setupproof@v0.1.3",
+		"cli-version: v0.1.3",
 		"require-blocks: \"true\"",
 		"files: |\n            README.md",
 	} {

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -17,9 +17,9 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 	doc := string(data)
 
 	for _, want := range []string{
-		"SetupProof v0.1.2 ships as a Go module",
-		"go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2",
-		"setupproof_0.1.2_checksums.txt",
+		"SetupProof v0.1.3 ships as a Go module",
+		"go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3",
+		"setupproof_0.1.3_checksums.txt",
 		"Native Windows execution is unsupported in v0.1",
 		"SetupProof through WSL2",
 		"PowerShell fenced blocks are unsupported in v0.1.",
@@ -53,8 +53,8 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 		"permissions:\n  contents: read",
 		"timeout-minutes: 10",
 		"uses: actions/checkout@v4",
-		"uses: setupproof/setupproof@v0.1.2",
-		"cli-version: v0.1.2",
+		"uses: setupproof/setupproof@v0.1.3",
+		"cli-version: v0.1.3",
 		"mode: review",
 		"require-blocks: \"true\"",
 	} {

--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -1,7 +1,7 @@
 {
   "name": "setupproof",
   "version": "__VERSION__",
-  "description": "Test marked README quickstarts from a clean workspace.",
+  "description": "Run README setup commands from a clean checkout before contributors copy them.",
   "license": "Apache-2.0",
   "homepage": "https://setupproof.github.io/setupproof/",
   "repository": {
@@ -11,6 +11,17 @@
   "bugs": {
     "url": "https://github.com/setupproof/setupproof/issues"
   },
+  "keywords": [
+    "readme",
+    "quickstart",
+    "ci",
+    "github-actions",
+    "documentation",
+    "markdown",
+    "setup",
+    "testing",
+    "developer-tools"
+  ],
   "bin": {
     "setupproof": "bin/setupproof"
   },

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -68,15 +68,15 @@ assert_contains "$DOC" "<!-- ci-snippet:generic-shell -->"
 assert_contains "$DOC" "Native Windows execution is unsupported in v0.1"
 assert_contains "$DOC" "PowerShell fenced blocks are unsupported in v0.1"
 assert_contains "$DOC" "WSL2"
-assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.2"
-assert_contains "$DOC" "setupproof_0.1.2_checksums.txt"
+assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3"
+assert_contains "$DOC" "setupproof_0.1.3_checksums.txt"
 assert_contains "$DOC" "setupproof review README.md"
 assert_contains "$DOC" "setupproof --report-json setupproof-report.json --require-blocks --no-color --no-glyphs README.md"
 assert_contains "$DOC" "require-blocks: \"true\""
 assert_contains "$ROOT/LICENSE" "Apache License"
 assert_contains "$ROOT/NOTICE" "Licensed under the Apache License, Version 2.0."
 assert_contains "$ROOT/README.md" 'Apache License, Version 2.0 (`Apache-2.0`)'
-assert_contains "$ROOT/README.md" "setupproof/setupproof@v0.1.2"
+assert_contains "$ROOT/README.md" "setupproof/setupproof@v0.1.3"
 assert_contains "$ROOT/examples/node-npm/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/package.json" '"license": "Apache-2.0"'
 assert_contains "$ROOT/examples/monorepo/packages/web/package.json" '"license": "Apache-2.0"'


### PR DESCRIPTION
## Summary
- Bump release-controlled references to v0.1.3.
- Update release notes, security wording, Marketplace decision docs, and npm package metadata.
- Keep npm, Homebrew, and Marketplace install claims deferred until those channels are verified live.

## Checks
- make fmt-check
- make docs
- make actionlint
- make check
- make staticcheck
- make vuln
- make release-check VERSION=0.1.3
- git diff --check
- public text and artifact strings audit