### PR TITLE
Define native Windows support scope

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform_support.md
+++ b/.github/ISSUE_TEMPLATE/platform_support.md
@@ -30,4 +30,5 @@ What setup-doc workflow should work on this platform?
 ## Notes
 
 Native Windows and PowerShell execution are outside v0.1 scope. Proposals for
-new platform behavior should explain test coverage and report compatibility.
+new platform behavior should start from ADR 0010 and explain test coverage,
+shell semantics, path behavior, environment behavior, and report compatibility.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -44,6 +44,13 @@ Marked blocks run as non-interactive shell scripts. Stdin is closed, no TTY is
 allocated, strict mode is enabled by default, and blocks in one target file share
 state unless a block is isolated.
 
+## Native Windows
+
+Native Windows execution remains outside v0.1 scope, and Windows users should
+run SetupProof through WSL2. ADR 0010 records the support boundary: native
+Windows requires explicit CI coverage plus shell, path, environment, workspace,
+and report compatibility decisions before docs or packages advertise support.
+
 ## Environment
 
 No user environment variables pass by default beyond the sanitized baseline.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -192,6 +192,10 @@ v0.1 platform support:
 - PowerShell fenced blocks are unsupported in v0.1. Use `sh`, `bash`, or
   `shell` fenced blocks for marked quickstarts.
 
+ADR 0010 records the native Windows support boundary and the CI, shell, path,
+environment, workspace, and report decisions required before native support is
+documented.
+
 For CI on untrusted pull requests, pass no secrets by default, prefer hosted
 ephemeral runners, and run `setupproof review README.md` before executing marked
 blocks.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -78,7 +78,9 @@ Marked shell fences need a supported shell. In v0.1, use `sh`, `bash`, or
 `shell` fences.
 
 Native Windows execution and PowerShell fences are unsupported in v0.1. On
-Windows, run SetupProof through WSL2.
+Windows, run SetupProof through WSL2. ADR 0010 records the native Windows
+support boundary and the compatibility work required before support is
+documented.
 
 ## Docker Runner Problems
 

--- a/docs/adr/0010-native-windows-support-scope.md
+++ b/docs/adr/0010-native-windows-support-scope.md
@@ -1,0 +1,69 @@
+# ADR 0010: Native Windows Support Scope
+
+Status: Accepted
+
+Date: 2026-07-07
+
+## Context
+
+SetupProof v0.1 supports Linux as the primary local and CI target, uses
+GitHub-hosted Ubuntu runners as the primary Action environment, treats macOS as
+best effort, and directs Windows users to WSL2. The current execution model is
+intentionally POSIX-shaped: marked `sh`, `bash`, and `shell` fences run as
+non-interactive scripts with closed stdin, no TTY, strict-mode prologues, shared
+per-file state, timeout handling, sanitized environment behavior, and temporary
+workspace copies.
+
+Native Windows support is not a packaging-only change. It affects shell
+selection, command quoting, drive-letter and UNC paths, backslash separators,
+case-insensitive environment variables, CRLF handling, symlink behavior,
+temporary workspace copying, process-tree termination, and report
+compatibility.
+
+## Decision
+
+Native Windows execution remains unsupported in v0.1. Windows users should run
+SetupProof through WSL2 until native support is explicitly designed,
+implemented, and tested.
+
+The current v0.1 shell contract remains:
+
+- `sh`, `bash`, and `shell` fences are supported.
+- `shell` means `sh`.
+- PowerShell and `cmd` fences are unsupported.
+- Release archives and install docs advertise Linux and macOS binaries, not
+  native Windows binaries.
+
+Native Windows support must not be documented as available until all of these
+conditions are met:
+
+- Windows CI coverage runs the relevant CLI, runner, report, and docs tests on
+  GitHub-hosted Windows runners.
+- A path contract covers drive-letter paths, UNC paths, backslash normalization,
+  relative paths, workspace roots, and report paths.
+- An environment contract covers case-insensitive names, baseline variables,
+  pass-through variables, required variables, and redaction.
+- A shell contract decides whether PowerShell, `cmd`, or both are supported,
+  and how strict mode, line continuations, working directory updates, exported
+  state, stdin closure, no-TTY execution, timeouts, and process-tree cleanup
+  behave.
+- Workspace copy behavior covers Windows file modes, symlinks, ignored files,
+  untracked files, linked worktrees, submodules, temporary directories, and
+  cleanup.
+- Report JSON and terminal output stay compatible with existing schemas and
+  consumers, or any schema change is handled through the public schema process.
+- Install and troubleshooting docs continue to name WSL2 as the Windows path
+  until native Windows binaries and behavior are verified.
+
+Implementation should land as focused follow-up issues instead of opportunistic
+platform changes mixed into unrelated runner, packaging, or docs pull requests.
+
+## Consequences
+
+- Current Windows documentation remains intentionally narrow and points to WSL2.
+- Platform proposals have a checklist for the semantics and CI coverage they
+  must define before support can be advertised.
+- Native Windows packaging is blocked on execution semantics and CI coverage,
+  not only on adding another release archive target.
+- PowerShell support is treated as an explicit shell-design decision, not as an
+  automatic side effect of running on Windows.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -4,6 +4,7 @@ set -eu
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 DOC="$ROOT/docs/INSTALL.md"
+NATIVE_WINDOWS_ADR="$ROOT/docs/adr/0010-native-windows-support-scope.md"
 PUBLIC_DOCS="$ROOT/README.md
 $ROOT/LICENSE
 $ROOT/CODE_OF_CONDUCT.md
@@ -57,6 +58,7 @@ assert_not_contains() {
 }
 
 [ -f "$DOC" ] || fail "missing docs/INSTALL.md"
+[ -f "$NATIVE_WINDOWS_ADR" ] || fail "missing native Windows ADR"
 [ -f "$ROOT/schemas/setupproof-config.schema.json" ] || fail "missing config schema"
 for file in $PUBLIC_DOCS; do
   [ -f "$file" ] || fail "missing public doc: $file"
@@ -69,6 +71,13 @@ assert_contains "$DOC" "<!-- ci-snippet:generic-shell -->"
 assert_contains "$DOC" "Native Windows execution is unsupported in v0.1"
 assert_contains "$DOC" "PowerShell fenced blocks are unsupported in v0.1"
 assert_contains "$DOC" "WSL2"
+assert_contains "$DOC" "ADR 0010 records the native Windows support boundary"
+assert_contains "$NATIVE_WINDOWS_ADR" "Native Windows execution remains unsupported in v0.1"
+assert_contains "$NATIVE_WINDOWS_ADR" "Windows CI coverage runs the relevant CLI, runner, report, and docs tests"
+assert_contains "$NATIVE_WINDOWS_ADR" 'PowerShell and `cmd` fences are unsupported'
+assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0010 records the support boundary"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0010 records the native Windows"
+assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010"
 assert_contains "$DOC" "brew install setupproof/tap/setupproof"
 assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3"
 assert_contains "$DOC" "setupproof_0.1.3_checksums.txt"


### PR DESCRIPTION
## Summary
- add ADR 0010 to record the native Windows support boundary beyond WSL2
- keep install and troubleshooting docs explicit that native Windows and PowerShell remain unsupported in v0.1
- extend docs checks so the ADR and platform-support guidance stay present

Closes #30

## Follow-up issues
- #49
- #50
- #51
- #52

## Validation
- make check