### PR TITLE
Add Windows compatibility boundary checks

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -32,3 +32,18 @@ jobs:
         run: make actionlint
       - name: Verify release archives
         run: make release-check VERSION=0.1.3
+
+  windows-compatibility:
+    runs-on: windows-2025
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.8"
+          cache: true
+      - name: Run Windows compatibility boundary checks
+        shell: bash
+        run: sh scripts/check-windows-compatibility.sh

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ STATICCHECK_VERSION ?= v0.6.1
 GOVULNCHECK_VERSION ?= v1.1.4
 ACTIONLINT_VERSION ?= v1.7.7
 
-.PHONY: build test vet race fmt fmt-check dogfood foundation action docs examples schemas check staticcheck vuln actionlint release-archives npm-package npm-check release-check
+.PHONY: build test vet race fmt fmt-check dogfood foundation action docs examples schemas windows-compatibility check staticcheck vuln actionlint release-archives npm-package npm-check release-check
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o ./setupproof ./cmd/setupproof
@@ -41,6 +41,9 @@ examples:
 
 schemas:
 	go test -run TestPublishedSchemasHaveStableIDs ./internal/cli
+
+windows-compatibility:
+	sh scripts/check-windows-compatibility.sh
 
 check: test vet race foundation action docs examples schemas dogfood
 

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -14,7 +14,7 @@ func TestInstallDocCISnippetsAndDeferredClaims(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	doc := string(data)
+	doc := strings.ReplaceAll(string(data), "\r\n", "\n")
 
 	for _, want := range []string{
 		"SetupProof v0.1.3 ships as a Go module, Homebrew tap",

--- a/scripts/check-github-action.sh
+++ b/scripts/check-github-action.sh
@@ -492,6 +492,8 @@ test_summary_renderer_keeps_block_details() {
 }
 
 test_no_secret_default_workflow_shape() {
+  local release_checks="$ROOT/.github/workflows/release-checks.yml"
+
   assert_contains "$ROOT/action.yml" "default: action-local"
   assert_contains "$ROOT/action.yml" "default: \"true\""
   assert_contains "$ROOT/action.yml" "published release"
@@ -513,6 +515,14 @@ test_no_secret_default_workflow_shape() {
   assert_not_contains "$ROOT/.github/workflows/setupproof.yml" "secrets."
   assert_not_contains "$ROOT/.github/workflows/setupproof.yml" "github.token"
   assert_not_contains "$ROOT/.github/workflows/setupproof.yml" "@""v1"
+
+  assert_contains "$release_checks" "windows-compatibility:"
+  assert_contains "$release_checks" "runs-on: windows-2025"
+  assert_contains "$release_checks" "sh scripts/check-windows-compatibility.sh"
+  assert_not_contains "$release_checks" "pull_request_target"
+  assert_not_contains "$release_checks" "secrets."
+  assert_not_contains "$release_checks" "github.token"
+  assert_not_contains "$release_checks" "@""v1"
 }
 
 test_local_cli_input_mapping

--- a/scripts/check-windows-compatibility.sh
+++ b/scripts/check-windows-compatibility.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+cd "$ROOT"
+
+go test ./internal/platform
+go test -run 'TestInstallDocCISnippetsAndDeferredClaims|TestInitWorkflowPrintsConservativeWorkflowOnly' ./internal/cli
+sh scripts/check-docs.sh
+
+printf 'windows compatibility checks passed\n'


### PR DESCRIPTION
## Summary
- add a Windows Server 2025 compatibility job to the release checks workflow
- add a reusable compatibility script for the current Windows support boundary
- assert the workflow keeps read-only, no-secret release-check behavior

This keeps native Windows support gated behind explicit validation without advertising it as supported.

Closes #49

## Validation
- make windows-compatibility
- make action
- make check
- make actionlint