### PR TITLE
Define native Windows shell semantics

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform_support.md
+++ b/.github/ISSUE_TEMPLATE/platform_support.md
@@ -30,5 +30,6 @@ What setup-doc workflow should work on this platform?
 ## Notes
 
 Native Windows and PowerShell execution are outside v0.1 scope. Proposals for
-new platform behavior should start from ADR 0010 and explain test coverage,
-shell semantics, path behavior, environment behavior, and report compatibility.
+new platform behavior should start from ADR 0010 and ADR 0011, then explain
+test coverage, shell semantics, path behavior, environment behavior, and report
+compatibility.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -50,6 +50,9 @@ Native Windows execution remains outside v0.1 scope, and Windows users should
 run SetupProof through WSL2. ADR 0010 records the support boundary: native
 Windows requires explicit CI coverage plus shell, path, environment, workspace,
 and report compatibility decisions before docs or packages advertise support.
+ADR 0011 records the current shell decision: `shell` stays POSIX `sh`, and
+PowerShell, `pwsh`, and `cmd` fences remain unsupported until a future ADR
+changes that contract.
 
 ## Environment
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -194,7 +194,8 @@ v0.1 platform support:
 
 ADR 0010 records the native Windows support boundary and the CI, shell, path,
 environment, workspace, and report decisions required before native support is
-documented.
+documented. ADR 0011 records the current shell decision: `shell` means POSIX
+`sh`, not PowerShell or `cmd`.
 
 For CI on untrusted pull requests, pass no secrets by default, prefer hosted
 ephemeral runners, and run `setupproof review README.md` before executing marked

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -80,7 +80,8 @@ Marked shell fences need a supported shell. In v0.1, use `sh`, `bash`, or
 Native Windows execution and PowerShell fences are unsupported in v0.1. On
 Windows, run SetupProof through WSL2. ADR 0010 records the native Windows
 support boundary and the compatibility work required before support is
-documented.
+documented. ADR 0011 records that `shell` remains POSIX `sh`, not PowerShell
+or `cmd`.
 
 ## Docker Runner Problems
 

--- a/docs/adr/0011-native-windows-shell-semantics.md
+++ b/docs/adr/0011-native-windows-shell-semantics.md
@@ -1,0 +1,59 @@
+# ADR 0011: Native Windows Shell Semantics
+
+Status: Accepted
+
+Date: 2026-07-07
+
+## Context
+
+ADR 0010 keeps native Windows execution outside v0.1 scope. The current
+execution model is POSIX-shaped and supports only `sh`, `bash`, and `shell`
+fences. Native Windows support needs a separate shell decision before users can
+reason about command syntax, strict-mode behavior, state persistence, timeout
+cleanup, and report output.
+
+PowerShell and `cmd` differ materially from POSIX shells. They use different
+quoting rules, line continuations, environment access syntax, exit-status
+conventions, path parsing, and command-discovery behavior. Treating them as an
+implicit variation of `shell` would make review output and CI behavior
+ambiguous.
+
+## Decision
+
+Native Windows shell execution is not supported in v0.1.
+
+The v0.1 shell contract remains:
+
+- `sh` fences run with the `sh` shell.
+- `bash` fences run with the `bash` shell.
+- `shell` fences are an alias for `sh`.
+- `powershell`, `pwsh`, and `cmd` fences are unsupported, including when they
+  are explicitly marked for SetupProof.
+- Unsupported marked shell languages fail during planning and do not produce an
+  executable block.
+- The local and Action runners must not reinterpret `shell` as PowerShell or
+  `cmd` on Windows.
+
+Future native Windows shell support requires a new ADR or an accepted update to
+this ADR. That decision must define:
+
+- the accepted fence language names and any aliases;
+- strict-mode prologues for each supported shell;
+- line-continuation handling and interactive-command detection;
+- stdin closure and no-TTY behavior;
+- current-working-directory state between blocks;
+- exported or persisted environment state between blocks;
+- timeout and process-tree cleanup behavior;
+- command quoting and source-vs-prologue reporting boundaries;
+- JSON report values for `language`, `shell`, `stdin`, `tty`, `stateMode`,
+  `reason`, and timeout cleanup details.
+
+## Consequences
+
+- Current Windows users continue to run SetupProof through WSL2.
+- Review, dry-run, terminal, Markdown, and JSON outputs keep one unambiguous
+  meaning for `shell`: POSIX `sh`.
+- PowerShell and `cmd` work can be split into focused implementation issues
+  after the path, environment, workspace, and report contracts are ready.
+- Windows CI should keep checking that native Windows shell fences fail clearly
+  until native shell support is intentionally added.

--- a/internal/planning/planning_test.go
+++ b/internal/planning/planning_test.go
@@ -265,6 +265,35 @@ blocks:
 	}
 }
 
+func TestBuildRejectsNativeWindowsShellLanguages(t *testing.T) {
+	for _, language := range []string{"powershell", "pwsh", "cmd"} {
+		t.Run(language, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "README.md", "```"+language+" setupproof id=install\nWrite-Output ok\n```\n")
+
+			result, err := Build(Request{
+				CWD:              dir,
+				Positional:       []string{"README.md"},
+				HasRequireBlocks: true,
+				RequireBlocks:    true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.ExitCode != 2 {
+				t.Fatalf("exit code = %d, errors = %#v", result.ExitCode, result.Plan.ValidationErrors)
+			}
+			if len(result.Plan.Blocks) != 0 {
+				t.Fatalf("blocks = %#v", result.Plan.Blocks)
+			}
+			want := `README.md:1: marked block language "` + language + `" is not supported; use sh, bash, or shell`
+			if !contains(result.Plan.ValidationErrors, want) {
+				t.Fatalf("validation errors = %#v", result.Plan.ValidationErrors)
+			}
+		})
+	}
+}
+
 func TestBuildRejectsNetworkFalseForLocalRunner(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "README.md", "```sh setupproof network=false\nnpm test\n```\n")

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 DOC="$ROOT/docs/INSTALL.md"
 NATIVE_WINDOWS_ADR="$ROOT/docs/adr/0010-native-windows-support-scope.md"
+NATIVE_WINDOWS_SHELL_ADR="$ROOT/docs/adr/0011-native-windows-shell-semantics.md"
 PUBLIC_DOCS="$ROOT/README.md
 $ROOT/LICENSE
 $ROOT/CODE_OF_CONDUCT.md
@@ -59,6 +60,7 @@ assert_not_contains() {
 
 [ -f "$DOC" ] || fail "missing docs/INSTALL.md"
 [ -f "$NATIVE_WINDOWS_ADR" ] || fail "missing native Windows ADR"
+[ -f "$NATIVE_WINDOWS_SHELL_ADR" ] || fail "missing native Windows shell ADR"
 [ -f "$ROOT/schemas/setupproof-config.schema.json" ] || fail "missing config schema"
 for file in $PUBLIC_DOCS; do
   [ -f "$file" ] || fail "missing public doc: $file"
@@ -72,12 +74,18 @@ assert_contains "$DOC" "Native Windows execution is unsupported in v0.1"
 assert_contains "$DOC" "PowerShell fenced blocks are unsupported in v0.1"
 assert_contains "$DOC" "WSL2"
 assert_contains "$DOC" "ADR 0010 records the native Windows support boundary"
+assert_contains "$DOC" "ADR 0011 records the current shell decision"
 assert_contains "$NATIVE_WINDOWS_ADR" "Native Windows execution remains unsupported in v0.1"
 assert_contains "$NATIVE_WINDOWS_ADR" "Windows CI coverage runs the relevant CLI, runner, report, and docs tests"
 assert_contains "$NATIVE_WINDOWS_ADR" 'PowerShell and `cmd` fences are unsupported'
+assert_contains "$NATIVE_WINDOWS_SHELL_ADR" "Native Windows shell execution is not supported in v0.1"
+assert_contains "$NATIVE_WINDOWS_SHELL_ADR" '`powershell`, `pwsh`, and `cmd` fences are unsupported'
+assert_contains "$NATIVE_WINDOWS_SHELL_ADR" 'The local and Action runners must not reinterpret `shell`'
 assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0010 records the support boundary"
+assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0011 records the current shell decision"
 assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0010 records the native Windows"
-assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" 'ADR 0011 records that `shell` remains POSIX'
+assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010 and ADR 0011"
 assert_contains "$DOC" "brew install setupproof/tap/setupproof"
 assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3"
 assert_contains "$DOC" "setupproof_0.1.3_checksums.txt"

--- a/scripts/check-windows-compatibility.sh
+++ b/scripts/check-windows-compatibility.sh
@@ -6,6 +6,7 @@ ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 cd "$ROOT"
 
 go test ./internal/platform
+go test -run 'TestBuildRejectsNativeWindowsShellLanguages|TestBuildRejectsUnsupportedMarkedLanguage' ./internal/planning
 go test -run 'TestInstallDocCISnippetsAndDeferredClaims|TestInitWorkflowPrintsConservativeWorkflowOnly' ./internal/cli
 sh scripts/check-docs.sh
 


### PR DESCRIPTION
## Summary
- add ADR 0011 for the native Windows shell contract
- document that `shell` remains POSIX `sh`, not PowerShell or `cmd`
- add planning coverage for rejecting marked `powershell`, `pwsh`, and `cmd` fences
- include the shell rejection tests in the Windows compatibility check

Closes #50

## Validation
- go test -run 'TestBuildRejectsNativeWindowsShellLanguages|TestBuildRejectsUnsupportedMarkedLanguage' ./internal/planning
- make docs
- make windows-compatibility
- make foundation
- make actionlint
- make check