### PR TITLE
Define native Windows path and environment semantics

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform_support.md
+++ b/.github/ISSUE_TEMPLATE/platform_support.md
@@ -30,6 +30,6 @@ What setup-doc workflow should work on this platform?
 ## Notes
 
 Native Windows and PowerShell execution are outside v0.1 scope. Proposals for
-new platform behavior should start from ADR 0010 and ADR 0011, then explain
-test coverage, shell semantics, path behavior, environment behavior, and report
-compatibility.
+new platform behavior should start from ADR 0010, ADR 0011, and ADR 0012, then
+explain test coverage, shell semantics, path behavior, environment behavior,
+and report compatibility.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -52,7 +52,10 @@ Windows requires explicit CI coverage plus shell, path, environment, workspace,
 and report compatibility decisions before docs or packages advertise support.
 ADR 0011 records the current shell decision: `shell` stays POSIX `sh`, and
 PowerShell, `pwsh`, and `cmd` fences remain unsupported until a future ADR
-changes that contract.
+changes that contract. ADR 0012 records the current path and environment
+decision: repository paths stay slash-normalized, runner environments are
+allowlist-built, and native Windows case-insensitive environment handling is
+not supported until a future ADR changes that contract.
 
 ## Environment
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -195,7 +195,9 @@ v0.1 platform support:
 ADR 0010 records the native Windows support boundary and the CI, shell, path,
 environment, workspace, and report decisions required before native support is
 documented. ADR 0011 records the current shell decision: `shell` means POSIX
-`sh`, not PowerShell or `cmd`.
+`sh`, not PowerShell or `cmd`. ADR 0012 records the path and environment
+decision: repository paths stay slash-normalized and native Windows
+environment behavior remains unsupported.
 
 For CI on untrusted pull requests, pass no secrets by default, prefer hosted
 ephemeral runners, and run `setupproof review README.md` before executing marked

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -81,7 +81,8 @@ Native Windows execution and PowerShell fences are unsupported in v0.1. On
 Windows, run SetupProof through WSL2. ADR 0010 records the native Windows
 support boundary and the compatibility work required before support is
 documented. ADR 0011 records that `shell` remains POSIX `sh`, not PowerShell
-or `cmd`.
+or `cmd`. ADR 0012 records that native Windows path and environment behavior
+remains unsupported.
 
 ## Docker Runner Problems
 

--- a/docs/adr/0012-native-windows-path-and-environment-semantics.md
+++ b/docs/adr/0012-native-windows-path-and-environment-semantics.md
@@ -1,0 +1,69 @@
+# ADR 0012: Native Windows Path And Environment Semantics
+
+Status: Accepted
+
+Date: 2026-07-07
+
+## Context
+
+ADR 0010 keeps native Windows execution outside v0.1 scope, and ADR 0011 keeps
+PowerShell and `cmd` fences unsupported. Native Windows support also needs an
+explicit path and environment contract before SetupProof can safely advertise
+native execution.
+
+Windows path and environment behavior differs from the current POSIX-shaped
+runner model. Drive-letter paths, UNC paths, backslash separators,
+case-insensitive environment names, process-level environment inheritance, and
+report path rendering all affect reviewability and JSON compatibility.
+
+## Decision
+
+Native Windows path and environment behavior remains unsupported in v0.1.
+Windows users should run SetupProof through WSL2.
+
+The current v0.1 contract remains:
+
+- Repository file identities in plans and reports use repository-relative slash
+  paths.
+- Git-provided workspace paths must resolve inside the repository root before
+  copying.
+- Absolute Git workspace paths, including native Windows drive-letter and UNC
+  paths, are invalid as copied repository-relative paths.
+- The runner builds a sanitized environment from an allowlist instead of
+  inheriting the process environment wholesale.
+- `HOME` and `TMPDIR` point inside the temporary workspace for local and
+  `action-local` execution.
+- `PATH` may be inherited for local and `action-local` so documented POSIX
+  setup commands can find host tools.
+- `env.allow` and `env.pass` names are explicit and are reported by name only.
+- `env.pass` values marked `secret: true` are redacted from supported output
+  sinks.
+- Native Windows case-insensitive environment-name handling is not supported
+  until a native Windows environment contract is accepted.
+
+Future native Windows path and environment support requires a new ADR or an
+accepted update to this ADR. That decision must define:
+
+- whether report and plan paths remain slash-normalized or expose native
+  separators;
+- how drive-letter paths, UNC paths, and extended-length paths are displayed and
+  validated;
+- how relative paths are resolved from the invocation directory, repository
+  root, temporary workspace, config file, and report destinations;
+- how case-insensitive environment names are canonicalized and deduplicated;
+- which baseline variables are set, renamed, or omitted on native Windows;
+- whether `HOME`, `USERPROFILE`, `TMP`, `TEMP`, and `TMPDIR` are all set, and
+  where they point;
+- how redaction handles case-insensitive variable names without redacting
+  unrelated values;
+- how schema compatibility is preserved for existing plan and report consumers.
+
+## Consequences
+
+- Public docs continue to name WSL2 as the Windows path.
+- Native Windows path and environment work can proceed behind explicit CI
+  checks without changing user-facing support claims.
+- Existing reports keep stable repository-relative path strings and named-only
+  environment metadata.
+- Native Windows packaging remains blocked until the path, environment,
+  workspace, report, and shell contracts are all implemented and verified.

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -628,6 +629,75 @@ func TestLocalStateCWDValidationRejectsOutsideSymlink(t *testing.T) {
 	}
 }
 
+func TestCleanGitRelativePathRejectsNativeWindowsAbsolutePaths(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows path handling is checked on Windows CI")
+	}
+	for _, rel := range []string{
+		`C:/repo/README.md`,
+		`C:\repo\README.md`,
+		`//server/share/README.md`,
+		`\\server\share\README.md`,
+	} {
+		t.Run(rel, func(t *testing.T) {
+			if _, err := cleanGitRelativePath(rel); err == nil {
+				t.Fatalf("expected %q to be rejected as a repository-relative path", rel)
+			}
+		})
+	}
+}
+
+func TestBaselineEnvUsesWorkspaceScopedPathsAndSecretValues(t *testing.T) {
+	t.Setenv("PATH", "host-tool-path")
+	t.Setenv("LANG", "unsafe-locale")
+	t.Setenv("LC_ALL", "unsafe-lc-all")
+	t.Setenv("SETUPPROOF_ALLOWED_ENV", "allowed-value")
+	t.Setenv("SETUPPROOF_SECRET_ENV", "secret-value")
+
+	wsRoot := t.TempDir()
+	ws := &workspace{
+		homeDir: filepath.Join(wsRoot, "home"),
+		tmpDir:  filepath.Join(wsRoot, "tmp"),
+	}
+	envPlan := planning.Env{
+		Allow: []string{"SETUPPROOF_ALLOWED_ENV", "SETUPPROOF_MISSING_ENV"},
+		Pass: []planning.EnvPass{
+			{Name: "SETUPPROOF_SECRET_ENV", Secret: true},
+		},
+	}
+
+	var stderr bytes.Buffer
+	env, secretValues, err := baselineEnv(envPlan, ws, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := envValues(env)
+
+	for name, want := range map[string]string{
+		"HOME":                   ws.homeDir,
+		"TMPDIR":                 ws.tmpDir,
+		"PATH":                   "host-tool-path",
+		"LANG":                   "C.UTF-8",
+		"CI":                     "true",
+		"SETUPPROOF":             "1",
+		"SETUPPROOF_ALLOWED_ENV": "allowed-value",
+		"SETUPPROOF_SECRET_ENV":  "secret-value",
+	} {
+		if got := values[name]; got != want {
+			t.Fatalf("%s = %q, want %q in env %#v", name, got, want, env)
+		}
+	}
+	if _, ok := values["LC_ALL"]; ok {
+		t.Fatalf("unsafe LC_ALL should be omitted from baseline env: %#v", env)
+	}
+	if len(secretValues) != 1 || secretValues[0] != "secret-value" {
+		t.Fatalf("secret values = %#v", secretValues)
+	}
+	if !strings.Contains(stderr.String(), "warning: optional environment variable SETUPPROOF_MISSING_ENV is not set") {
+		t.Fatalf("missing env warning = %q", stderr.String())
+	}
+}
+
 func runLocal(t *testing.T, dir string, req planning.Request, opts Options) (int, string, string) {
 	t.Helper()
 	if req.CWD == "" {
@@ -673,6 +743,17 @@ func writeFile(t *testing.T, root string, rel string, contents string) {
 	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func envValues(env []string) map[string]string {
+	values := make(map[string]string, len(env))
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[name] = value
+		}
+	}
+	return values
 }
 
 func keptWorkspacePath(t *testing.T, stderr string) string {

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -6,6 +6,7 @@ ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 DOC="$ROOT/docs/INSTALL.md"
 NATIVE_WINDOWS_ADR="$ROOT/docs/adr/0010-native-windows-support-scope.md"
 NATIVE_WINDOWS_SHELL_ADR="$ROOT/docs/adr/0011-native-windows-shell-semantics.md"
+NATIVE_WINDOWS_PATH_ENV_ADR="$ROOT/docs/adr/0012-native-windows-path-and-environment-semantics.md"
 PUBLIC_DOCS="$ROOT/README.md
 $ROOT/LICENSE
 $ROOT/CODE_OF_CONDUCT.md
@@ -61,6 +62,7 @@ assert_not_contains() {
 [ -f "$DOC" ] || fail "missing docs/INSTALL.md"
 [ -f "$NATIVE_WINDOWS_ADR" ] || fail "missing native Windows ADR"
 [ -f "$NATIVE_WINDOWS_SHELL_ADR" ] || fail "missing native Windows shell ADR"
+[ -f "$NATIVE_WINDOWS_PATH_ENV_ADR" ] || fail "missing native Windows path/env ADR"
 [ -f "$ROOT/schemas/setupproof-config.schema.json" ] || fail "missing config schema"
 for file in $PUBLIC_DOCS; do
   [ -f "$file" ] || fail "missing public doc: $file"
@@ -75,17 +77,23 @@ assert_contains "$DOC" "PowerShell fenced blocks are unsupported in v0.1"
 assert_contains "$DOC" "WSL2"
 assert_contains "$DOC" "ADR 0010 records the native Windows support boundary"
 assert_contains "$DOC" "ADR 0011 records the current shell decision"
+assert_contains "$DOC" "ADR 0012 records the path and environment"
 assert_contains "$NATIVE_WINDOWS_ADR" "Native Windows execution remains unsupported in v0.1"
 assert_contains "$NATIVE_WINDOWS_ADR" "Windows CI coverage runs the relevant CLI, runner, report, and docs tests"
 assert_contains "$NATIVE_WINDOWS_ADR" 'PowerShell and `cmd` fences are unsupported'
 assert_contains "$NATIVE_WINDOWS_SHELL_ADR" "Native Windows shell execution is not supported in v0.1"
 assert_contains "$NATIVE_WINDOWS_SHELL_ADR" '`powershell`, `pwsh`, and `cmd` fences are unsupported'
 assert_contains "$NATIVE_WINDOWS_SHELL_ADR" 'The local and Action runners must not reinterpret `shell`'
+assert_contains "$NATIVE_WINDOWS_PATH_ENV_ADR" "Native Windows path and environment behavior remains unsupported in v0.1"
+assert_contains "$NATIVE_WINDOWS_PATH_ENV_ADR" "Absolute Git workspace paths, including native Windows drive-letter and UNC"
+assert_contains "$NATIVE_WINDOWS_PATH_ENV_ADR" "Native Windows case-insensitive environment-name handling is not supported"
 assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0010 records the support boundary"
 assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0011 records the current shell decision"
+assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0012 records the current path and environment"
 assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0010 records the native Windows"
 assert_contains "$ROOT/docs/TROUBLESHOOTING.md" 'ADR 0011 records that `shell` remains POSIX'
-assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010 and ADR 0011"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0012 records that native Windows path and environment"
+assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010, ADR 0011, and ADR 0012"
 assert_contains "$DOC" "brew install setupproof/tap/setupproof"
 assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3"
 assert_contains "$DOC" "setupproof_0.1.3_checksums.txt"

--- a/scripts/check-windows-compatibility.sh
+++ b/scripts/check-windows-compatibility.sh
@@ -7,6 +7,7 @@ cd "$ROOT"
 
 go test ./internal/platform
 go test -run 'TestBuildRejectsNativeWindowsShellLanguages|TestBuildRejectsUnsupportedMarkedLanguage' ./internal/planning
+go test -run 'TestCleanGitRelativePathRejectsNativeWindowsAbsolutePaths|TestBaselineEnvUsesWorkspaceScopedPathsAndSecretValues' ./internal/runner
 go test -run 'TestInstallDocCISnippetsAndDeferredClaims|TestInitWorkflowPrintsConservativeWorkflowOnly' ./internal/cli
 sh scripts/check-docs.sh
 


### PR DESCRIPTION
## Summary
- add ADR 0012 for native Windows path and environment semantics
- document that repository paths stay slash-normalized and native Windows environment behavior remains unsupported in v0.1
- add runner coverage for Windows absolute path rejection and sanitized workspace-scoped environments
- include the runner checks in the Windows compatibility job

Closes #51

## Validation
- go test -run 'TestCleanGitRelativePathRejectsNativeWindowsAbsolutePaths|TestBaselineEnvUsesWorkspaceScopedPathsAndSecretValues' ./internal/runner
- make docs
- make windows-compatibility
- make foundation
- make actionlint
- make check
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/setupproof-runner-windows.test.exe ./internal/runner