### PR TITLE
Verify native Windows workspace and report compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform_support.md
+++ b/.github/ISSUE_TEMPLATE/platform_support.md
@@ -30,6 +30,6 @@ What setup-doc workflow should work on this platform?
 ## Notes
 
 Native Windows and PowerShell execution are outside v0.1 scope. Proposals for
-new platform behavior should start from ADR 0010, ADR 0011, and ADR 0012, then
-explain test coverage, shell semantics, path behavior, environment behavior,
-and report compatibility.
+new platform behavior should start from ADR 0010, ADR 0011, ADR 0012, and ADR
+0013, then explain test coverage, shell semantics, path behavior, environment
+behavior, workspace copying, and report compatibility.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -21,7 +21,8 @@ info-string form.
 
 Execution uses a Git tracked-plus-modified temporary copy by default. The copy
 includes tracked files as they exist in the working tree, excludes ignored and
-untracked files by default, and omits `.git`.
+untracked files by default, omits `.git`, and reports omitted Git submodule
+Gitlink entries.
 
 ## Runners
 
@@ -55,7 +56,10 @@ PowerShell, `pwsh`, and `cmd` fences remain unsupported until a future ADR
 changes that contract. ADR 0012 records the current path and environment
 decision: repository paths stay slash-normalized, runner environments are
 allowlist-built, and native Windows case-insensitive environment handling is
-not supported until a future ADR changes that contract.
+not supported until a future ADR changes that contract. ADR 0013 records the
+current workspace and report compatibility decision: native Windows tests cover
+Git workspace copying and schema-compatible unsupported-platform reports
+without advertising native execution support.
 
 ## Environment
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -197,7 +197,10 @@ environment, workspace, and report decisions required before native support is
 documented. ADR 0011 records the current shell decision: `shell` means POSIX
 `sh`, not PowerShell or `cmd`. ADR 0012 records the path and environment
 decision: repository paths stay slash-normalized and native Windows
-environment behavior remains unsupported.
+environment behavior remains unsupported. ADR 0013 records the workspace and
+report compatibility decision: native Windows tests may cover Git workspace
+copying and unsupported-platform reports without advertising native execution
+support.
 
 For CI on untrusted pull requests, pass no secrets by default, prefer hosted
 ephemeral runners, and run `setupproof review README.md` before executing marked

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -82,7 +82,8 @@ Windows, run SetupProof through WSL2. ADR 0010 records the native Windows
 support boundary and the compatibility work required before support is
 documented. ADR 0011 records that `shell` remains POSIX `sh`, not PowerShell
 or `cmd`. ADR 0012 records that native Windows path and environment behavior
-remains unsupported.
+remains unsupported. ADR 0013 records that native Windows workspace and report
+compatibility checks do not imply native execution support.
 
 ## Docker Runner Problems
 

--- a/docs/adr/0003-workspace-copy-semantics.md
+++ b/docs/adr/0003-workspace-copy-semantics.md
@@ -22,6 +22,8 @@ Default copy mode:
 - Exclude ignored files.
 - Exclude untracked files.
 - Exclude the `.git` directory.
+- Omit Git submodule Gitlink entries from the copied workspace and report when
+  they were omitted.
 - Report when the copied workspace differs from `HEAD`.
 - Reject target, config, and copied symlink paths that resolve outside the
   repository root.
@@ -57,4 +59,6 @@ Temporary workspace behavior:
 - The implementation must not describe the workspace as a clean checkout.
 - Reports should use `tracked-plus-modified` as the default workspace source
   name.
+- Submodule-dependent setup commands need a future explicit copy policy before
+  submodule working trees are copied into temporary workspaces.
 - A future non-Git execution mode needs its own explicit copy-mode decision.

--- a/docs/adr/0013-native-windows-workspace-and-report-compatibility.md
+++ b/docs/adr/0013-native-windows-workspace-and-report-compatibility.md
@@ -1,0 +1,69 @@
+# ADR 0013: Native Windows Workspace And Report Compatibility
+
+Status: Accepted
+
+Date: 2026-07-07
+
+## Context
+
+ADR 0010 keeps native Windows execution outside v0.1 scope. ADR 0011 keeps
+native Windows shell execution unsupported, and ADR 0012 keeps native Windows
+path and environment behavior unsupported. The remaining compatibility work is
+to verify that workspace copying and report output have a conservative,
+schema-compatible boundary before SetupProof can ever advertise native Windows
+support.
+
+Native Windows differs from the current POSIX-shaped runner in file modes,
+symlink privileges, temporary-directory behavior, submodule checkout shape,
+linked worktree metadata, path separators, and report consumers that expect
+repository-relative path strings.
+
+## Decision
+
+Native Windows workspace execution remains unsupported in v0.1. Windows users
+should run SetupProof through WSL2.
+
+The current v0.1 compatibility contract remains:
+
+- Workspace-copy helpers are tested on native Windows without executing marked
+  shell blocks.
+- Tracked files are copied from the Git working tree, including staged and
+  unstaged tracked modifications.
+- Ignored files and untracked files are omitted by default.
+- `--include-untracked` copies untracked non-ignored files and reports the
+  count.
+- Temporary workspaces include workspace-scoped home and tmp directories.
+- Cleanup makes copied trees writable before removal so read-only files do not
+  leave temporary directories behind.
+- Symlinks are copied only when the host permits symlink creation, and copied
+  symlink targets must resolve inside the repository root.
+- Linked worktrees are treated as their own Git workspace root.
+- Git submodule Gitlink entries are omitted from copied workspaces and reported
+  as omitted submodule paths.
+- Report JSON and terminal output keep repository file identities
+  slash-normalized, including on native Windows.
+- Native Windows execution reports stop at `unsupported_platform` and remain
+  valid against the published report schema.
+
+Future native Windows workspace support requires a new ADR or an accepted
+update to this ADR. That decision must define:
+
+- whether submodule working tree contents are copied, materialized, or remain
+  explicitly omitted;
+- how Windows junctions, reparse points, and unavailable symlink privileges are
+  represented;
+- how file modes and executable bits are reported when native Windows cannot
+  preserve POSIX permissions;
+- where temporary workspaces are created for local and Action runners;
+- how cleanup reports partial removal failures;
+- whether report paths continue to use slash-normalized repository-relative
+  paths for all consumers.
+
+## Consequences
+
+- Public docs continue to name WSL2 as the Windows path.
+- Native Windows CI can verify workspace and report compatibility without
+  implying native execution support.
+- Existing plan and report schemas do not change for this compatibility work.
+- Submodule-dependent setup commands need a future explicit copy policy before
+  native Windows support can be advertised.

--- a/internal/cli/report_windows_test.go
+++ b/internal/cli/report_windows_test.go
@@ -1,0 +1,96 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNativeWindowsUnsupportedExecutionReportStaysSchemaCompatible(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "")
+	dir := gitRepoForCLI(t)
+	writeCLIFile(t, dir, filepath.ToSlash(filepath.Join("docs", "README.md")), "```sh setupproof id=quickstart\ntrue\n```\n")
+	runGit(t, dir, "add", "--", filepath.ToSlash(filepath.Join("docs", "README.md")))
+	if err := os.Mkdir(filepath.Join(dir, "reports"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+
+	reportPath := filepath.Join("reports", "setupproof-report.json")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run([]string{"--json", "--report-json", reportPath, "--no-color", "--no-glyphs", "docs/README.md"}, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("exit code = %d, stderr = %q, stdout = %q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "native Windows execution is unsupported in v0.1") {
+		t.Fatalf("stderr missing native Windows boundary: %q", stderr.String())
+	}
+	validateJSONSchema(t, "schemas/setupproof-report.schema.json", stdout.Bytes())
+
+	reportFile := filepath.Join(dir, reportPath)
+	reportBytes, err := os.ReadFile(reportFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateJSONSchema(t, "schemas/setupproof-report.schema.json", reportBytes)
+	if !bytes.Equal(stdout.Bytes(), reportBytes) {
+		t.Fatalf("stdout report and file report differ\nstdout=%s\nfile=%s", stdout.String(), string(reportBytes))
+	}
+
+	var parsed struct {
+		Result    string   `json:"result"`
+		ExitCode  int      `json:"exitCode"`
+		Files     []string `json:"files"`
+		Workspace struct {
+			Mode              string `json:"mode"`
+			Source            string `json:"source"`
+			IncludedUntracked bool   `json:"includedUntracked"`
+		} `json:"workspace"`
+		Runner struct {
+			Kind  string `json:"kind"`
+			Error struct {
+				Reason string `json:"reason"`
+			} `json:"error"`
+		} `json:"runner"`
+		Blocks []json.RawMessage `json:"blocks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Result != "error" || parsed.ExitCode != 3 || parsed.Runner.Error.Reason != "unsupported_platform" {
+		t.Fatalf("unsupported platform report = %#v", parsed)
+	}
+	if parsed.Runner.Kind != "local" || parsed.Workspace.Mode != "temporary" || parsed.Workspace.Source != "tracked-plus-modified" {
+		t.Fatalf("runner/workspace report = %#v", parsed)
+	}
+	if len(parsed.Files) != 1 || parsed.Files[0] != "docs/README.md" || strings.Contains(parsed.Files[0], `\`) {
+		t.Fatalf("report files must stay slash-normalized: %#v", parsed.Files)
+	}
+	if len(parsed.Blocks) != 0 {
+		t.Fatalf("native Windows unsupported report should not include executed block reports: %#v", parsed.Blocks)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"--no-color", "--no-glyphs", "docs/README.md"}, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("terminal exit code = %d, stderr = %q, stdout = %q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		"SetupProof runner error runner=local reason=unsupported_platform",
+		"next command: setupproof doctor docs/README.md",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("terminal output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), `\`) {
+		t.Fatalf("terminal output should keep repository path slash-normalized:\n%s", stdout.String())
+	}
+}

--- a/internal/cli/schema_contract_test.go
+++ b/internal/cli/schema_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -207,11 +208,19 @@ func compileJSONSchema(t *testing.T, schemaRel string) *jsonschema.Schema {
 	schemaPath := filepath.Join(root, filepath.FromSlash(schemaRel))
 	compiler := jsonschema.NewCompiler()
 	compiler.DefaultDraft(jsonschema.Draft2020)
-	schema, err := compiler.Compile((&url.URL{Scheme: "file", Path: schemaPath}).String())
+	schema, err := compiler.Compile(fileURL(schemaPath))
 	if err != nil {
 		t.Fatalf("compile %s: %v", schemaRel, err)
 	}
 	return schema
+}
+
+func fileURL(path string) string {
+	path = filepath.ToSlash(path)
+	if filepath.VolumeName(path) != "" && !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
 func readFile(t *testing.T, path string) []byte {

--- a/internal/runner/local.go
+++ b/internal/runner/local.go
@@ -188,6 +188,11 @@ func prepareWorkspaceSource(req planning.Request, plan planning.Plan, stderr io.
 		fmt.Fprintf(stderr, "warning: %s\n", warning)
 		warnings = append(warnings, warning)
 	}
+	if source.submoduleFileCount > 0 {
+		warning := fmt.Sprintf("copied workspace omitted %d Git submodule path(s)", source.submoduleFileCount)
+		fmt.Fprintf(stderr, "warning: %s\n", warning)
+		warnings = append(warnings, warning)
+	}
 	return source, warnings, 0, "", true
 }
 

--- a/internal/runner/workspace.go
+++ b/internal/runner/workspace.go
@@ -17,6 +17,7 @@ type workspaceSource struct {
 	trackedChanged     bool
 	untrackedIncluded  bool
 	untrackedFileCount int
+	submoduleFileCount int
 }
 
 type workspace struct {
@@ -58,7 +59,7 @@ func gitWorkingTreeError(detail string) error {
 }
 
 func loadWorkspaceSource(root string, includeUntracked bool) (workspaceSource, error) {
-	tracked, err := gitListFiles(root, "--cached")
+	tracked, submoduleCount, err := gitListTrackedWorkspaceFiles(root)
 	if err != nil {
 		return workspaceSource{}, err
 	}
@@ -88,7 +89,38 @@ func loadWorkspaceSource(root string, includeUntracked bool) (workspaceSource, e
 		trackedChanged:     changed,
 		untrackedIncluded:  includeUntracked,
 		untrackedFileCount: untrackedCount,
+		submoduleFileCount: submoduleCount,
 	}, nil
+}
+
+func gitListTrackedWorkspaceFiles(root string) ([]string, int, error) {
+	cmd := exec.Command("git", "-C", root, "ls-files", "-z", "--stage")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list Git workspace files: %w", err)
+	}
+	parts := bytes.Split(out, []byte{0})
+	files := make([]string, 0, len(parts))
+	submoduleCount := 0
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		meta, pathBytes, ok := bytes.Cut(part, []byte{'\t'})
+		if !ok {
+			return nil, 0, fmt.Errorf("failed to parse Git workspace file entry %q", string(part))
+		}
+		mode, _, ok := strings.Cut(string(meta), " ")
+		if !ok || mode == "" {
+			return nil, 0, fmt.Errorf("failed to parse Git workspace file mode %q", string(meta))
+		}
+		if mode == "160000" {
+			submoduleCount++
+			continue
+		}
+		files = append(files, filepath.ToSlash(string(pathBytes)))
+	}
+	return files, submoduleCount, nil
 }
 
 func gitListFiles(root string, args ...string) ([]string, error) {

--- a/internal/runner/workspace_test.go
+++ b/internal/runner/workspace_test.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceSourceOmitsSubmoduleGitlinks(t *testing.T) {
+	submodule := gitRepo(t)
+	configureGitIdentity(t, submodule)
+	writeFile(t, submodule, "README.md", "submodule\n")
+	gitAdd(t, submodule, "README.md")
+	runGit(t, submodule, "commit", "-m", "initial")
+
+	parent := gitRepo(t)
+	configureGitIdentity(t, parent)
+	writeFile(t, parent, "README.md", "parent\n")
+	gitAdd(t, parent, "README.md")
+	runGit(t, parent, "commit", "-m", "initial")
+	runGit(t, parent, "-c", "protocol.file.allow=always", "submodule", "add", submodule, "vendor/submodule")
+
+	source, err := loadWorkspaceSource(parent, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.submoduleFileCount != 1 {
+		t.Fatalf("submodule count = %d, want 1 in %#v", source.submoduleFileCount, source)
+	}
+	if workspaceFileListed(source.files, "vendor/submodule") {
+		t.Fatalf("submodule gitlink should not be copied as a file: %#v", source.files)
+	}
+	if !workspaceFileListed(source.files, ".gitmodules") {
+		t.Fatalf(".gitmodules should remain copied: %#v", source.files)
+	}
+
+	ws, err := createWorkspaceInDir(source, t.TempDir(), "setupproof-local-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = ws.cleanup(false)
+	}()
+	if _, err := filepath.EvalSymlinks(filepath.Join(ws.repoRoot, "vendor", "submodule")); err == nil {
+		t.Fatal("submodule checkout should be omitted from copied workspace")
+	}
+}
+
+func configureGitIdentity(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "config", "user.email", "setupproof@example.invalid")
+	runGit(t, dir, "config", "user.name", "SetupProof Tests")
+}
+
+func workspaceFileListed(files []string, rel string) bool {
+	want := filepath.ToSlash(rel)
+	for _, file := range files {
+		if strings.EqualFold(filepath.ToSlash(file), want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/workspace_windows_test.go
+++ b/internal/runner/workspace_windows_test.go
@@ -1,0 +1,187 @@
+//go:build windows
+
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNativeWindowsWorkspaceCopiesGitLayoutsAndCleansTempDirs(t *testing.T) {
+	dir := gitRepo(t)
+	tempParent := t.TempDir()
+	t.Cleanup(func() {
+		_ = makeTreeWritable(dir)
+		_ = makeTreeWritable(tempParent)
+	})
+
+	writeFile(t, dir, ".gitignore", "ignored.txt\n")
+	writeFile(t, dir, "README.md", "```sh setupproof id=copy\ntrue\n```\n")
+	writeFile(t, dir, "tracked.txt", "tracked\n")
+	writeFile(t, dir, "readonly.txt", "readonly\n")
+	writeFile(t, dir, "ignored.txt", "ignored\n")
+	writeFile(t, dir, "untracked.txt", "untracked\n")
+	gitAdd(t, dir, ".gitignore", "README.md", "tracked.txt", "readonly.txt")
+	if err := os.Chmod(filepath.Join(dir, "readonly.txt"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	source, err := loadWorkspaceSource(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.untrackedIncluded || source.untrackedFileCount != 0 {
+		t.Fatalf("untracked source metadata = %#v", source)
+	}
+	for _, rel := range []string{"README.md", "tracked.txt", "readonly.txt"} {
+		if !workspaceFileListed(source.files, rel) {
+			t.Fatalf("tracked file %q missing from source files %#v", rel, source.files)
+		}
+	}
+	for _, rel := range []string{"ignored.txt", "untracked.txt", ".git"} {
+		if workspaceFileListed(source.files, rel) {
+			t.Fatalf("excluded file %q was listed in source files %#v", rel, source.files)
+		}
+	}
+
+	ws, err := createWorkspaceInDir(source, tempParent, "setupproof-local-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, filepath.Join(ws.repoRoot, "tracked.txt")); got != "tracked\n" {
+		t.Fatalf("tracked copy = %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(ws.repoRoot, "ignored.txt")); !os.IsNotExist(err) {
+		t.Fatalf("ignored file should not be copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ws.repoRoot, "untracked.txt")); !os.IsNotExist(err) {
+		t.Fatalf("untracked file should not be copied by default: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(ws.repoRoot, "readonly.txt"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := ws.cleanup(false); err != nil {
+		t.Fatal(err)
+	}
+	assertNoWorkspaces(t, tempParent)
+
+	source, err = loadWorkspaceSource(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !source.untrackedIncluded || source.untrackedFileCount != 1 {
+		t.Fatalf("include-untracked source metadata = %#v", source)
+	}
+	if !workspaceFileListed(source.files, "untracked.txt") {
+		t.Fatalf("untracked file missing from source files %#v", source.files)
+	}
+	if workspaceFileListed(source.files, "ignored.txt") {
+		t.Fatalf("ignored file was listed with include-untracked: %#v", source.files)
+	}
+}
+
+func TestNativeWindowsWorkspaceCopiesSymlinksWhenAvailable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "target.txt", "target\n")
+	if err := os.Symlink("target.txt", filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	ws, err := createWorkspaceInDir(workspaceSource{
+		root:  dir,
+		files: []string{"target.txt", "link.txt"},
+	}, t.TempDir(), "setupproof-local-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = ws.cleanup(false)
+	}()
+
+	target, err := os.Readlink(filepath.Join(ws.repoRoot, "link.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.ToSlash(target) != "target.txt" {
+		t.Fatalf("copied symlink target = %q", target)
+	}
+}
+
+func TestNativeWindowsWorkspaceSupportsLinkedWorktreeRoots(t *testing.T) {
+	root := gitRepo(t)
+	configureGitIdentity(t, root)
+	writeFile(t, root, "README.md", "linked root\n")
+	gitAdd(t, root, "README.md")
+	runGit(t, root, "commit", "-m", "initial")
+
+	linked := filepath.Join(t.TempDir(), "linked")
+	runGit(t, root, "worktree", "add", "-b", "linked-windows-test", linked)
+	writeFile(t, linked, "README.md", "linked worktree\n")
+	gitAdd(t, linked, "README.md")
+
+	discovered, err := discoverGitRoot(linked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(t, discovered, linked) {
+		t.Fatalf("discovered root = %q, want %q", discovered, linked)
+	}
+	source, err := loadWorkspaceSource(discovered, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !workspaceFileListed(source.files, "README.md") || source.trackedChanged != true {
+		t.Fatalf("linked worktree source = %#v", source)
+	}
+}
+
+func TestNativeWindowsWorkspaceOmitsSubmoduleGitlinks(t *testing.T) {
+	submodule := gitRepo(t)
+	configureGitIdentity(t, submodule)
+	writeFile(t, submodule, "README.md", "submodule\n")
+	gitAdd(t, submodule, "README.md")
+	runGit(t, submodule, "commit", "-m", "initial")
+
+	parent := gitRepo(t)
+	configureGitIdentity(t, parent)
+	writeFile(t, parent, "README.md", "parent\n")
+	gitAdd(t, parent, "README.md")
+	runGit(t, parent, "commit", "-m", "initial")
+	runGit(t, parent, "-c", "protocol.file.allow=always", "submodule", "add", submodule, "vendor/submodule")
+
+	source, err := loadWorkspaceSource(parent, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.submoduleFileCount != 1 {
+		t.Fatalf("submodule count = %d, want 1 in %#v", source.submoduleFileCount, source)
+	}
+	if workspaceFileListed(source.files, "vendor/submodule") {
+		t.Fatalf("submodule gitlink should not be copied as a file: %#v", source.files)
+	}
+	if !workspaceFileListed(source.files, ".gitmodules") {
+		t.Fatalf(".gitmodules should remain copied: %#v", source.files)
+	}
+
+	ws, err := createWorkspaceInDir(source, t.TempDir(), "setupproof-local-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = ws.cleanup(false)
+	}()
+	if _, err := os.Stat(filepath.Join(ws.repoRoot, "vendor", "submodule")); !os.IsNotExist(err) {
+		t.Fatalf("submodule checkout should be omitted from copied workspace: %v", err)
+	}
+}
+
+func samePath(t *testing.T, left string, right string) bool {
+	t.Helper()
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	return os.SameFile(leftInfo, rightInfo)
+}

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -7,6 +7,7 @@ DOC="$ROOT/docs/INSTALL.md"
 NATIVE_WINDOWS_ADR="$ROOT/docs/adr/0010-native-windows-support-scope.md"
 NATIVE_WINDOWS_SHELL_ADR="$ROOT/docs/adr/0011-native-windows-shell-semantics.md"
 NATIVE_WINDOWS_PATH_ENV_ADR="$ROOT/docs/adr/0012-native-windows-path-and-environment-semantics.md"
+NATIVE_WINDOWS_WORKSPACE_REPORT_ADR="$ROOT/docs/adr/0013-native-windows-workspace-and-report-compatibility.md"
 PUBLIC_DOCS="$ROOT/README.md
 $ROOT/LICENSE
 $ROOT/CODE_OF_CONDUCT.md
@@ -63,6 +64,7 @@ assert_not_contains() {
 [ -f "$NATIVE_WINDOWS_ADR" ] || fail "missing native Windows ADR"
 [ -f "$NATIVE_WINDOWS_SHELL_ADR" ] || fail "missing native Windows shell ADR"
 [ -f "$NATIVE_WINDOWS_PATH_ENV_ADR" ] || fail "missing native Windows path/env ADR"
+[ -f "$NATIVE_WINDOWS_WORKSPACE_REPORT_ADR" ] || fail "missing native Windows workspace/report ADR"
 [ -f "$ROOT/schemas/setupproof-config.schema.json" ] || fail "missing config schema"
 for file in $PUBLIC_DOCS; do
   [ -f "$file" ] || fail "missing public doc: $file"
@@ -78,6 +80,7 @@ assert_contains "$DOC" "WSL2"
 assert_contains "$DOC" "ADR 0010 records the native Windows support boundary"
 assert_contains "$DOC" "ADR 0011 records the current shell decision"
 assert_contains "$DOC" "ADR 0012 records the path and environment"
+assert_contains "$DOC" "ADR 0013 records the workspace and"
 assert_contains "$NATIVE_WINDOWS_ADR" "Native Windows execution remains unsupported in v0.1"
 assert_contains "$NATIVE_WINDOWS_ADR" "Windows CI coverage runs the relevant CLI, runner, report, and docs tests"
 assert_contains "$NATIVE_WINDOWS_ADR" 'PowerShell and `cmd` fences are unsupported'
@@ -87,13 +90,19 @@ assert_contains "$NATIVE_WINDOWS_SHELL_ADR" 'The local and Action runners must n
 assert_contains "$NATIVE_WINDOWS_PATH_ENV_ADR" "Native Windows path and environment behavior remains unsupported in v0.1"
 assert_contains "$NATIVE_WINDOWS_PATH_ENV_ADR" "Absolute Git workspace paths, including native Windows drive-letter and UNC"
 assert_contains "$NATIVE_WINDOWS_PATH_ENV_ADR" "Native Windows case-insensitive environment-name handling is not supported"
+assert_contains "$NATIVE_WINDOWS_WORKSPACE_REPORT_ADR" "Native Windows workspace execution remains unsupported in v0.1"
+assert_contains "$NATIVE_WINDOWS_WORKSPACE_REPORT_ADR" "Git submodule Gitlink entries are omitted"
+assert_contains "$NATIVE_WINDOWS_WORKSPACE_REPORT_ADR" 'Native Windows execution reports stop at `unsupported_platform`'
 assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0010 records the support boundary"
+assert_contains "$ROOT/docs/DECISIONS.md" "reports omitted Git submodule"
 assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0011 records the current shell decision"
 assert_contains "$ROOT/docs/DECISIONS.md" "ADR 0012 records the current path and environment"
+assert_contains "$ROOT/docs/DECISIONS.md" "current workspace and report compatibility decision"
 assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0010 records the native Windows"
 assert_contains "$ROOT/docs/TROUBLESHOOTING.md" 'ADR 0011 records that `shell` remains POSIX'
 assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0012 records that native Windows path and environment"
-assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010, ADR 0011, and ADR 0012"
+assert_contains "$ROOT/docs/TROUBLESHOOTING.md" "ADR 0013 records that native Windows workspace and report"
+assert_contains "$ROOT/.github/ISSUE_TEMPLATE/platform_support.md" "start from ADR 0010, ADR 0011, ADR 0012, and ADR"
 assert_contains "$DOC" "brew install setupproof/tap/setupproof"
 assert_contains "$DOC" "go install github.com/setupproof/setupproof/cmd/setupproof@v0.1.3"
 assert_contains "$DOC" "setupproof_0.1.3_checksums.txt"

--- a/scripts/check-windows-compatibility.sh
+++ b/scripts/check-windows-compatibility.sh
@@ -7,8 +7,8 @@ cd "$ROOT"
 
 go test ./internal/platform
 go test -run 'TestBuildRejectsNativeWindowsShellLanguages|TestBuildRejectsUnsupportedMarkedLanguage' ./internal/planning
-go test -run 'TestCleanGitRelativePathRejectsNativeWindowsAbsolutePaths|TestBaselineEnvUsesWorkspaceScopedPathsAndSecretValues' ./internal/runner
-go test -run 'TestInstallDocCISnippetsAndDeferredClaims|TestInitWorkflowPrintsConservativeWorkflowOnly' ./internal/cli
+go test -run 'TestCleanGitRelativePathRejectsNativeWindowsAbsolutePaths|TestBaselineEnvUsesWorkspaceScopedPathsAndSecretValues|TestNativeWindowsWorkspaceCopiesGitLayoutsAndCleansTempDirs|TestNativeWindowsWorkspaceCopiesSymlinksWhenAvailable|TestNativeWindowsWorkspaceSupportsLinkedWorktreeRoots|TestNativeWindowsWorkspaceOmitsSubmoduleGitlinks' ./internal/runner
+go test -run 'TestInstallDocCISnippetsAndDeferredClaims|TestInitWorkflowPrintsConservativeWorkflowOnly|TestNativeWindowsUnsupportedExecutionReportStaysSchemaCompatible' ./internal/cli
 sh scripts/check-docs.sh
 
 printf 'windows compatibility checks passed\n'


### PR DESCRIPTION
## Summary
- add ADR 0013 for native Windows workspace and report compatibility
- omit submodule Gitlinks from copied workspaces with an explicit warning
- add Windows compatibility tests for workspace layouts and unsupported-platform reports
- make schema validation use Windows-safe file URLs
- include the new checks in the Windows compatibility gate

Closes #52

## Validation
- go test -run 'TestWorkspaceSourceOmitsSubmoduleGitlinks|TestBaselineEnvUsesWorkspaceScopedPathsAndSecretValues' ./internal/runner
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/setupproof-runner-windows.test.exe ./internal/runner
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/setupproof-cli-windows.test.exe ./internal/cli
- make docs
- make windows-compatibility
- go test ./internal/runner
- go test ./internal/cli
- go test -run 'TestJSONOutputsMatchPublishedSchemas|TestPublishedSchemasHaveStableIDs' ./internal/cli
- make foundation
- make actionlint
- make check