### PR TITLE
Document Windows support boundary in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ jobs:
 - `docs/demo/terminal-demo.txt` is a checked transcript of the terminal demo.
 - `docs/ARCHITECTURE.md` explains the package map and core invariants.
 - `docs/DOCKER_RUNNER.md` documents Docker runner tradeoffs and trust boundaries.
-- `docs/INSTALL.md` covers release archives, GitHub Actions, and CI snippets.
+- `docs/INSTALL.md` covers release archives, GitHub Actions, CI snippets, and
+  v0.1 platform support, including WSL2 for Windows users.
 - `docs/RECIPES.md` collects copyable `setupproof.yml` starters for common repository layouts.
 - `docs/RELEASE_READINESS.md` lists release checks.
 - `docs/SCHEMAS.md` lists versioned JSON Schema URLs for plan, report, and config validation.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -119,6 +119,7 @@ assert_contains "$ROOT/examples/monorepo/packages/web/package.json" '"license": 
 assert_contains "$ROOT/examples/rust/Cargo.toml" 'license = "Apache-2.0"'
 assert_contains "$ROOT/README.md" "docs/ARCHITECTURE.md"
 assert_contains "$ROOT/README.md" "docs/DOCKER_RUNNER.md"
+assert_contains "$ROOT/README.md" "v0.1 platform support, including WSL2 for Windows users"
 assert_contains "$ROOT/README.md" "docs/RECIPES.md"
 assert_contains "$ROOT/README.md" "docs/TROUBLESHOOTING.md"
 assert_contains "$ROOT/README.md" "docs/SCHEMAS.md"


### PR DESCRIPTION
Summary:
- Points README readers from the docs list to v0.1 platform support details in docs/INSTALL.md.
- Calls out WSL2 as the documented Windows path from the README surface.
- Adds a docs-check assertion so the README keeps that platform-support pointer.

Validation:
- sh scripts/check-docs.sh
- make check