### PR TITLE
Strengthen npm package release check

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -32,6 +32,9 @@ npm package gates:
 - The package bundles Linux and macOS binaries for `amd64`/`arm64`; it does not
   use postinstall scripts, install-time downloads, native builds, telemetry, or
   hidden update checks.
+- The generated binary manifest must list each supported platform/architecture
+  exactly once, match the release checksum manifest, and declare every vendored
+  binary shipped in the package.
 - `scripts/check-npm-package.sh` runs `npm pack --dry-run`, packs the tarball,
   installs it into a clean temporary project, and verifies
   `setupproof --version`.

--- a/scripts/check-npm-package.sh
+++ b/scripts/check-npm-package.sh
@@ -20,6 +20,8 @@ case "$VERSION" in
 esac
 
 PLAIN_VERSION="${VERSION#v}"
+DIST="$ROOT/dist/$VERSION"
+CHECKSUM_MANIFEST="$DIST/setupproof_${PLAIN_VERSION}_checksums.txt"
 PKG_ROOT="$ROOT/dist/$VERSION/npm/package"
 
 fail() {
@@ -33,6 +35,7 @@ command -v npm >/dev/null 2>&1 || fail "npm is required"
 [ -d "$PKG_ROOT" ] || "$ROOT/scripts/package-npm.sh" "$VERSION" >/dev/null
 [ -f "$PKG_ROOT/package.json" ] || fail "missing generated package.json"
 [ -f "$PKG_ROOT/vendor/manifest.json" ] || fail "missing generated binary manifest"
+[ -f "$CHECKSUM_MANIFEST" ] || fail "missing checksum manifest: $CHECKSUM_MANIFEST"
 
 node -e '
 const fs = require("fs");
@@ -44,6 +47,130 @@ if (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) {
   throw new Error("production dependencies are not allowed");
 }
 ' "$PKG_ROOT/package.json"
+
+node - <<'NODE' "$PKG_ROOT" "$PLAIN_VERSION" "$CHECKSUM_MANIFEST"
+const fs = require("fs");
+const path = require("path");
+
+const [pkgRoot, version, checksumManifest] = process.argv.slice(2);
+const manifestPath = path.join(pkgRoot, "vendor", "manifest.json");
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assertRelativePath(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail("binary path must be a non-empty string");
+  }
+  if (path.isAbsolute(value) || value.split(/[\\/]+/).includes("..")) {
+    fail(`binary path must stay inside the package: ${value}`);
+  }
+}
+
+const expected = new Map([
+  ["linux/x64", {
+    path: "vendor/linux-x64/setupproof",
+    archive: `setupproof_${version}_linux_amd64.tar.gz`,
+  }],
+  ["linux/arm64", {
+    path: "vendor/linux-arm64/setupproof",
+    archive: `setupproof_${version}_linux_arm64.tar.gz`,
+  }],
+  ["darwin/x64", {
+    path: "vendor/darwin-x64/setupproof",
+    archive: `setupproof_${version}_darwin_amd64.tar.gz`,
+  }],
+  ["darwin/arm64", {
+    path: "vendor/darwin-arm64/setupproof",
+    archive: `setupproof_${version}_darwin_arm64.tar.gz`,
+  }],
+]);
+
+const checksums = new Map();
+for (const line of fs.readFileSync(checksumManifest, "utf8").trim().split(/\n+/)) {
+  const match = line.match(/^([0-9a-f]{64})\s+(\S+)$/i);
+  if (!match) {
+    fail(`invalid checksum manifest line: ${line}`);
+  }
+  checksums.set(match[2], match[1].toLowerCase());
+}
+
+if (manifest.version !== version) {
+  fail(`manifest version ${manifest.version} does not match ${version}`);
+}
+if (!Array.isArray(manifest.binaries)) {
+  fail("manifest binaries must be an array");
+}
+if (manifest.binaries.length !== expected.size) {
+  fail(`manifest must list ${expected.size} binaries, found ${manifest.binaries.length}`);
+}
+
+const seen = new Set();
+const declaredFiles = new Set(["vendor/manifest.json"]);
+
+for (const entry of manifest.binaries) {
+  const key = `${entry.platform}/${entry.arch}`;
+  const want = expected.get(key);
+  if (!want) {
+    fail(`unsupported binary entry: ${key}`);
+  }
+  if (seen.has(key)) {
+    fail(`duplicate binary entry: ${key}`);
+  }
+  seen.add(key);
+
+  assertRelativePath(entry.path);
+  if (entry.path !== want.path) {
+    fail(`${key} path ${entry.path} does not match ${want.path}`);
+  }
+  if (entry.archive !== want.archive) {
+    fail(`${key} archive ${entry.archive} does not match ${want.archive}`);
+  }
+  if (!/^[0-9a-f]{64}$/i.test(entry.sha256 || "")) {
+    fail(`${key} sha256 must be a 64-character hex digest`);
+  }
+  const checksum = checksums.get(entry.archive);
+  if (!checksum) {
+    fail(`${key} archive is missing from the release checksum manifest`);
+  }
+  if (checksum !== entry.sha256.toLowerCase()) {
+    fail(`${key} sha256 does not match the release checksum manifest`);
+  }
+
+  const binaryPath = path.join(pkgRoot, entry.path);
+  const stat = fs.statSync(binaryPath);
+  if (!stat.isFile()) {
+    fail(`${entry.path} is not a file`);
+  }
+  if ((stat.mode & 0o111) === 0) {
+    fail(`${entry.path} is not executable`);
+  }
+  declaredFiles.add(entry.path);
+}
+
+for (const key of expected.keys()) {
+  if (!seen.has(key)) {
+    fail(`missing binary entry: ${key}`);
+  }
+}
+
+function walk(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const fullPath = path.join(dir, name);
+    const relative = path.relative(pkgRoot, fullPath).split(path.sep).join("/");
+    const stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      walk(fullPath);
+    } else if (!declaredFiles.has(relative)) {
+      fail(`undeclared vendor file: ${relative}`);
+    }
+  }
+}
+
+walk(path.join(pkgRoot, "vendor"));
+NODE
 
 version_output=$("$PKG_ROOT/bin/setupproof" --version)
 [ "$version_output" = "setupproof $PLAIN_VERSION" ] || fail "unexpected wrapper version output: $version_output"


### PR DESCRIPTION
## Summary
- validate the generated npm binary manifest against supported platform and architecture entries
- ensure manifest archive checksums match the release checksum manifest
- reject undeclared files in the npm vendor directory and document the release gate

## Validation
- sh scripts/check-npm-package.sh v0.1.3
- sh scripts/check-docs.sh
- make release-check VERSION=0.1.3
- make check